### PR TITLE
feat: bootstrap enterprise cli

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: ci
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Check formatting
+        run: test -z "$(gofmt -l .)"
+
+      - name: Check module tidiness
+        run: |
+          go mod tidy
+          git diff --exit-code -- go.mod go.sum
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Test
+        run: go test -race -coverprofile=coverage.out ./...
+
+      - name: Build
+        run: go build -trimpath -o dist/galaxio ./cmd/galaxio

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    name: goreleaser
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 # https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
 #
 # Binaries for programs and plugins
+bin/
+dist/
 *.exe
 *.exe~
 *.dll

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,61 @@
+version: 2
+
+project_name: galaxio
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - id: galaxio
+    main: ./cmd/galaxio
+    binary: galaxio
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w -X github.com/galax-io/galaxio-cli/internal/buildinfo.Version={{.Version}} -X github.com/galax-io/galaxio-cli/internal/buildinfo.Commit={{.ShortCommit}} -X github.com/galax-io/galaxio-cli/internal/buildinfo.Date={{.Date}}
+
+archives:
+  - id: galaxio
+    formats:
+      - tar.gz
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+
+checksum:
+  name_template: checksums.txt
+
+changelog:
+  use: github
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^chore:"
+      - "^ci:"
+      - "^style:"
+  groups:
+    - title: Features
+      regexp: "^feat"
+      order: 0
+    - title: Fixes
+      regexp: "^fix"
+      order: 1
+    - title: Other Changes
+      order: 999
+
+release:
+  github:
+    owner: galax-io
+    name: galaxio-cli

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be generated from Conventional Commits
+by GoReleaser when a `v*` tag is pushed.
+
+## Unreleased
+
+- Bootstrap minimal enterprise-style CLI.
+- Add version output, minimal help, stable exit-code mapping, and global
+  `--no-color`, `--verbose`, and `--quiet` flags.
+- Add CI for formatting, module tidiness, vet, tests, and build.
+- Add tag-driven GoReleaser configuration.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,114 @@
 # galaxio-cli
+
+`galaxio` is a minimal, enterprise-style command-line application scaffolded for
+predictable automation, stable releases, and idiomatic Go development.
+
+## Features
+
+- Minimal help and version commands.
+- Stable exit codes: `0` for success, `1` for runtime failures, and `2` for
+  command-line usage errors.
+- Global `--no-color`, `--verbose`, and `--quiet` flags.
+- Version metadata embedded at build time with Go linker flags.
+- Unit-tested Cobra command execution.
+- CI for formatting, module tidiness, vet, tests, and binary build.
+- Tag-driven releases with GoReleaser.
+
+## Requirements
+
+- Go 1.24 or newer.
+
+## Usage
+
+Print help:
+
+```sh
+galaxio --help
+```
+
+Print version information:
+
+```sh
+galaxio version
+galaxio --version
+```
+
+Use global output-control flags:
+
+```sh
+galaxio --verbose version
+galaxio --quiet version
+galaxio --no-color version
+```
+
+## Build
+
+Build a local binary:
+
+```sh
+go build -o bin/galaxio ./cmd/galaxio
+```
+
+Build with version metadata:
+
+```sh
+go build \
+  -ldflags "-X github.com/galax-io/galaxio-cli/internal/buildinfo.Version=v0.1.0 \
+    -X github.com/galax-io/galaxio-cli/internal/buildinfo.Commit=$(git rev-parse --short HEAD) \
+    -X github.com/galax-io/galaxio-cli/internal/buildinfo.Date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  -o bin/galaxio ./cmd/galaxio
+```
+
+## Test
+
+Run the test suite:
+
+```sh
+go test ./...
+```
+
+Run the same core checks as CI:
+
+```sh
+test -z "$(gofmt -l .)"
+go mod tidy
+go vet ./...
+go test -race -coverprofile=coverage.out ./...
+go build -trimpath -o dist/galaxio ./cmd/galaxio
+```
+
+## Install
+
+Install from the current checkout:
+
+```sh
+go install ./cmd/galaxio
+```
+
+Install from the module path:
+
+```sh
+go install github.com/galax-io/galaxio-cli/cmd/galaxio@latest
+```
+
+## Release
+
+Releases are driven by Git tags. Create and push a semver tag:
+
+```sh
+git tag v0.1.0
+git push origin v0.1.0
+```
+
+The release workflow runs GoReleaser, builds cross-platform archives, publishes
+checksums, and generates release notes from Conventional Commits.
+
+## Conventional Commits
+
+Use Conventional Commits so generated changelogs stay readable:
+
+```text
+feat: add profile configuration
+fix: return usage exit code for invalid arguments
+chore: update ci workflow
+```

--- a/cmd/galaxio/errors.go
+++ b/cmd/galaxio/errors.go
@@ -1,0 +1,54 @@
+package main
+
+import "errors"
+
+const (
+	exitOK      = 0
+	exitRuntime = 1
+	exitUsage   = 2
+)
+
+// UsageError marks invalid command-line usage such as bad flags, bad
+// arguments, or unknown commands.
+type UsageError struct {
+	Err error
+}
+
+func (e UsageError) Error() string {
+	return e.Err.Error()
+}
+
+func (e UsageError) Unwrap() error {
+	return e.Err
+}
+
+// RuntimeError marks a failure that happened while executing a valid command.
+type RuntimeError struct {
+	Err error
+}
+
+func (e RuntimeError) Error() string {
+	return e.Err.Error()
+}
+
+func (e RuntimeError) Unwrap() error {
+	return e.Err
+}
+
+func exitCode(err error) int {
+	if err == nil {
+		return exitOK
+	}
+
+	var usageErr UsageError
+	if errors.As(err, &usageErr) {
+		return exitUsage
+	}
+
+	var runtimeErr RuntimeError
+	if errors.As(err, &runtimeErr) {
+		return exitRuntime
+	}
+
+	return exitUsage
+}

--- a/cmd/galaxio/main.go
+++ b/cmd/galaxio/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"os"
+)
+
+func main() {
+	os.Exit(execute(os.Args[1:], os.Stdout, os.Stderr))
+}

--- a/cmd/galaxio/root.go
+++ b/cmd/galaxio/root.go
@@ -1,0 +1,69 @@
+// Package main contains the galaxio command-line application.
+package main
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+)
+
+type globalOptions struct {
+	noColor bool
+	verbose bool
+	quiet   bool
+}
+
+// newRootCommand builds the root command for the galaxio CLI.
+func newRootCommand() *cobra.Command {
+	opts := &globalOptions{}
+
+	cmd := &cobra.Command{
+		Use:           "galaxio",
+		Short:         "Enterprise command-line toolkit for Galaxio.",
+		Long:          "Enterprise command-line toolkit for Galaxio platform workflows.",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		Version:       buildVersionString(),
+		Args:          cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if opts.verbose && opts.quiet {
+				return UsageError{Err: fmt.Errorf("--verbose and --quiet cannot be used together")}
+			}
+			return nil
+		},
+	}
+
+	cmd.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
+		return UsageError{Err: err}
+	})
+
+	cmd.PersistentFlags().BoolVar(&opts.noColor, "no-color", false, "disable colored output")
+	cmd.PersistentFlags().BoolVarP(&opts.verbose, "verbose", "v", false, "enable verbose diagnostic output")
+	cmd.PersistentFlags().BoolVarP(&opts.quiet, "quiet", "q", false, "suppress non-essential output")
+
+	cmd.AddCommand(newVersionCommand())
+
+	return cmd
+}
+
+func execute(args []string, stdout io.Writer, stderr io.Writer) int {
+	cmd := newRootCommand()
+	cmd.SetArgs(args)
+	cmd.SetOut(stdout)
+	cmd.SetErr(stderr)
+
+	err := cmd.Execute()
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "Error: %s\n", err)
+	}
+
+	return exitCode(err)
+}
+
+func buildVersionString() string {
+	return versionInfo().CleanVersion()
+}

--- a/cmd/galaxio/root_test.go
+++ b/cmd/galaxio/root_test.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/galax-io/galaxio-cli/internal/buildinfo"
+)
+
+func runCLI(args ...string) (int, string, string) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	code := execute(args, &stdout, &stderr)
+
+	return code, stdout.String(), stderr.String()
+}
+
+func TestHelpPrintsMinimalUsage(t *testing.T) {
+	code, stdout, stderr := runCLI("--help")
+
+	if code != exitOK {
+		t.Fatalf("expected exit code %d, got %d", exitOK, code)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	for _, want := range []string{"Enterprise command-line toolkit", "Usage:", "galaxio [flags]", "completion", "version"} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("expected help output to contain %q, got %q", want, stdout)
+		}
+	}
+}
+
+func TestRootWithoutArgsPrintsHelp(t *testing.T) {
+	code, stdout, stderr := runCLI()
+
+	if code != exitOK {
+		t.Fatalf("expected exit code %d, got %d", exitOK, code)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, "Usage:") {
+		t.Fatalf("expected help output, got %q", stdout)
+	}
+}
+
+func TestVersionCommandPrintsBuildInfo(t *testing.T) {
+	code, stdout, stderr := runCLI("version")
+
+	if code != exitOK {
+		t.Fatalf("expected exit code %d, got %d", exitOK, code)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if want := "galaxio dev (commit none, built unknown)"; !strings.Contains(stdout, want) {
+		t.Fatalf("expected version output to contain %q, got %q", want, stdout)
+	}
+}
+
+func TestVersionCommandTrimsTagPrefix(t *testing.T) {
+	originalVersion := versionInfo().Version
+	buildinfo.Version = "v1.2.3"
+	t.Cleanup(func() {
+		buildinfo.Version = originalVersion
+	})
+
+	code, stdout, stderr := runCLI("version")
+
+	if code != exitOK {
+		t.Fatalf("expected exit code %d, got %d", exitOK, code)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if want := "galaxio 1.2.3"; !strings.Contains(stdout, want) {
+		t.Fatalf("expected version output to contain %q, got %q", want, stdout)
+	}
+}
+
+func TestVersionFlagPrintsVersion(t *testing.T) {
+	code, stdout, stderr := runCLI("--version")
+
+	if code != exitOK {
+		t.Fatalf("expected exit code %d, got %d", exitOK, code)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if want := "galaxio version dev"; !strings.Contains(stdout, want) {
+		t.Fatalf("expected version flag output to contain %q, got %q", want, stdout)
+	}
+}
+
+func TestUnknownCommandReturnsUsageExitCode(t *testing.T) {
+	code, stdout, stderr := runCLI("missing")
+
+	if code != exitUsage {
+		t.Fatalf("expected exit code %d, got %d", exitUsage, code)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "unknown command") {
+		t.Fatalf("expected unknown command error, got %q", stderr)
+	}
+	if strings.Contains(stderr, "Usage:") {
+		t.Fatalf("expected no usage dump on error, got %q", stderr)
+	}
+}
+
+func TestVerboseAndQuietAreMutuallyExclusive(t *testing.T) {
+	code, stdout, stderr := runCLI("--verbose", "--quiet", "version")
+
+	if code != exitUsage {
+		t.Fatalf("expected exit code %d, got %d", exitUsage, code)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "--verbose and --quiet cannot be used together") {
+		t.Fatalf("expected mutual exclusion error, got %q", stderr)
+	}
+}
+
+func TestExitCodeMapping(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{name: "ok", err: nil, want: exitOK},
+		{name: "usage", err: UsageError{Err: errors.New("bad args")}, want: exitUsage},
+		{name: "runtime", err: RuntimeError{Err: errors.New("boom")}, want: exitRuntime},
+		{name: "unknown defaults to usage", err: errors.New("unknown command"), want: exitUsage},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := exitCode(tt.err); got != tt.want {
+				t.Fatalf("expected exit code %d, got %d", tt.want, got)
+			}
+		})
+	}
+}

--- a/cmd/galaxio/version.go
+++ b/cmd/galaxio/version.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/galax-io/galaxio-cli/internal/buildinfo"
+	"github.com/spf13/cobra"
+)
+
+func newVersionCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Print version information.",
+		Long:  "Print version, commit, and build date information for the galaxio binary.",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if err := cobra.NoArgs(cmd, args); err != nil {
+				return UsageError{Err: err}
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			_, err := fmt.Fprintln(cmd.OutOrStdout(), versionInfo().String())
+			if err != nil {
+				return RuntimeError{Err: err}
+			}
+			return nil
+		},
+	}
+}
+
+func versionInfo() buildinfo.Info {
+	return buildinfo.Current()
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module github.com/galax-io/galaxio-cli
+
+go 1.24.0
+
+require github.com/spf13/cobra v1.10.1
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.9 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.10.1 h1:lJeBwCfmrnXthfAupyUTzJ/J4Nc1RsHC/mSRU2dll/s=
+github.com/spf13/cobra v1.10.1/go.mod h1:7SmJGaTHFVBY0jW4NXGluQoLvhqFQM+6XSKD+P4XaB0=
+github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
+github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/buildinfo/buildinfo.go
+++ b/internal/buildinfo/buildinfo.go
@@ -1,0 +1,39 @@
+// Package buildinfo exposes metadata embedded into the galaxio binary at build
+// time.
+package buildinfo
+
+import "fmt"
+import "strings"
+
+// These values are overwritten by release builds through -ldflags.
+var (
+	Version = "dev"
+	Commit  = "none"
+	Date    = "unknown"
+)
+
+// Info contains version metadata for the running binary.
+type Info struct {
+	Version string `json:"version"`
+	Commit  string `json:"commit"`
+	Date    string `json:"date"`
+}
+
+// Current returns the build metadata compiled into the binary.
+func Current() Info {
+	return Info{
+		Version: Version,
+		Commit:  Commit,
+		Date:    Date,
+	}
+}
+
+// String formats build metadata for human-readable CLI output.
+func (i Info) String() string {
+	return fmt.Sprintf("galaxio %s (commit %s, built %s)", i.CleanVersion(), i.Commit, i.Date)
+}
+
+// CleanVersion returns Version without the common git tag prefix.
+func (i Info) CleanVersion() string {
+	return strings.TrimPrefix(i.Version, "v")
+}

--- a/internal/buildinfo/buildinfo_test.go
+++ b/internal/buildinfo/buildinfo_test.go
@@ -1,0 +1,56 @@
+package buildinfo
+
+import "testing"
+
+func TestCurrentReturnsBuildVariables(t *testing.T) {
+	originalVersion := Version
+	originalCommit := Commit
+	originalDate := Date
+	t.Cleanup(func() {
+		Version = originalVersion
+		Commit = originalCommit
+		Date = originalDate
+	})
+
+	Version = "v1.2.3"
+	Commit = "abc1234"
+	Date = "2026-04-29T12:00:00Z"
+
+	got := Current()
+
+	if got.Version != Version {
+		t.Fatalf("expected version %q, got %q", Version, got.Version)
+	}
+	if got.Commit != Commit {
+		t.Fatalf("expected commit %q, got %q", Commit, got.Commit)
+	}
+	if got.Date != Date {
+		t.Fatalf("expected date %q, got %q", Date, got.Date)
+	}
+}
+
+func TestInfoString(t *testing.T) {
+	info := Info{
+		Version: "1.2.3",
+		Commit:  "abc1234",
+		Date:    "2026-04-29T12:00:00Z",
+	}
+
+	want := "galaxio 1.2.3 (commit abc1234, built 2026-04-29T12:00:00Z)"
+	if got := info.String(); got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
+func TestInfoStringTrimsVersionPrefix(t *testing.T) {
+	info := Info{
+		Version: "v1.2.3",
+		Commit:  "abc1234",
+		Date:    "2026-04-29T12:00:00Z",
+	}
+
+	want := "galaxio 1.2.3 (commit abc1234, built 2026-04-29T12:00:00Z)"
+	if got := info.String(); got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}


### PR DESCRIPTION
## Summary

- Bootstrap a minimal enterprise-style Go CLI using Cobra.
- Add version output with build metadata normalized without the `v` tag prefix.
- Add stable exit-code mapping, global output-control flags, unit tests, CI, GoReleaser, README, and CHANGELOG.

## Validation

- `go test ./...`
- `go vet ./...`
- `go test -race -coverprofile=coverage.out ./...`
- `go build -trimpath -o dist/galaxio ./cmd/galaxio`
- `test -z "$(gofmt -l .)"`
- `go mod tidy && git diff --exit-code -- go.mod go.sum`
