### PR TITLE
fix: derive version from go build metadata

### DIFF
--- a/internal/buildinfo/buildinfo.go
+++ b/internal/buildinfo/buildinfo.go
@@ -1,9 +1,11 @@
-// Package buildinfo exposes metadata embedded into the galaxio binary at build
-// time.
+// Package buildinfo exposes metadata embedded into the galaxio binary.
 package buildinfo
 
-import "fmt"
-import "strings"
+import (
+	"fmt"
+	"runtime/debug"
+	"strings"
+)
 
 // These values are overwritten by release builds through -ldflags.
 var (
@@ -11,6 +13,8 @@ var (
 	Commit  = "none"
 	Date    = "unknown"
 )
+
+var readBuildInfo = debug.ReadBuildInfo
 
 // Info contains version metadata for the running binary.
 type Info struct {
@@ -21,11 +25,37 @@ type Info struct {
 
 // Current returns the build metadata compiled into the binary.
 func Current() Info {
-	return Info{
+	info := Info{
 		Version: Version,
 		Commit:  Commit,
 		Date:    Date,
 	}
+
+	build, ok := readBuildInfo()
+	if !ok {
+		return info
+	}
+
+	if isDefaultVersion(info.Version) && build.Main.Version != "" && build.Main.Version != "(devel)" {
+		info.Version = build.Main.Version
+	}
+
+	settings := buildSettings(build.Settings)
+	if info.Commit == "none" {
+		info.Commit = settings["vcs.revision"]
+		if len(info.Commit) > 12 {
+			info.Commit = info.Commit[:12]
+		}
+		if info.Commit == "" {
+			info.Commit = "none"
+		}
+	}
+
+	if info.Date == "unknown" && settings["vcs.time"] != "" {
+		info.Date = settings["vcs.time"]
+	}
+
+	return info
 }
 
 // String formats build metadata for human-readable CLI output.
@@ -36,4 +66,16 @@ func (i Info) String() string {
 // CleanVersion returns Version without the common git tag prefix.
 func (i Info) CleanVersion() string {
 	return strings.TrimPrefix(i.Version, "v")
+}
+
+func isDefaultVersion(version string) bool {
+	return version == "" || version == "dev"
+}
+
+func buildSettings(settings []debug.BuildSetting) map[string]string {
+	result := make(map[string]string, len(settings))
+	for _, setting := range settings {
+		result[setting.Key] = setting.Value
+	}
+	return result
 }

--- a/internal/buildinfo/buildinfo_test.go
+++ b/internal/buildinfo/buildinfo_test.go
@@ -1,20 +1,28 @@
 package buildinfo
 
-import "testing"
+import (
+	"runtime/debug"
+	"testing"
+)
 
 func TestCurrentReturnsBuildVariables(t *testing.T) {
 	originalVersion := Version
 	originalCommit := Commit
 	originalDate := Date
+	originalReadBuildInfo := readBuildInfo
 	t.Cleanup(func() {
 		Version = originalVersion
 		Commit = originalCommit
 		Date = originalDate
+		readBuildInfo = originalReadBuildInfo
 	})
 
 	Version = "v1.2.3"
 	Commit = "abc1234"
 	Date = "2026-04-29T12:00:00Z"
+	readBuildInfo = func() (*debug.BuildInfo, bool) {
+		return nil, false
+	}
 
 	got := Current()
 
@@ -26,6 +34,75 @@ func TestCurrentReturnsBuildVariables(t *testing.T) {
 	}
 	if got.Date != Date {
 		t.Fatalf("expected date %q, got %q", Date, got.Date)
+	}
+}
+
+func TestCurrentFallsBackToModuleVersion(t *testing.T) {
+	originalVersion := Version
+	originalCommit := Commit
+	originalDate := Date
+	originalReadBuildInfo := readBuildInfo
+	t.Cleanup(func() {
+		Version = originalVersion
+		Commit = originalCommit
+		Date = originalDate
+		readBuildInfo = originalReadBuildInfo
+	})
+
+	Version = "dev"
+	Commit = "none"
+	Date = "unknown"
+	readBuildInfo = func() (*debug.BuildInfo, bool) {
+		return &debug.BuildInfo{
+			Main: debug.Module{Version: "v1.2.3"},
+			Settings: []debug.BuildSetting{
+				{Key: "vcs.revision", Value: "abcdef1234567890"},
+				{Key: "vcs.time", Value: "2026-04-29T12:00:00Z"},
+			},
+		}, true
+	}
+
+	got := Current()
+
+	if got.Version != "v1.2.3" {
+		t.Fatalf("expected module version fallback, got %q", got.Version)
+	}
+	if got.Commit != "abcdef123456" {
+		t.Fatalf("expected shortened vcs revision, got %q", got.Commit)
+	}
+	if got.Date != "2026-04-29T12:00:00Z" {
+		t.Fatalf("expected vcs time fallback, got %q", got.Date)
+	}
+	if want := "galaxio 1.2.3 (commit abcdef123456, built 2026-04-29T12:00:00Z)"; got.String() != want {
+		t.Fatalf("expected %q, got %q", want, got.String())
+	}
+}
+
+func TestCurrentKeepsDevVersionForLocalBuilds(t *testing.T) {
+	originalVersion := Version
+	originalCommit := Commit
+	originalDate := Date
+	originalReadBuildInfo := readBuildInfo
+	t.Cleanup(func() {
+		Version = originalVersion
+		Commit = originalCommit
+		Date = originalDate
+		readBuildInfo = originalReadBuildInfo
+	})
+
+	Version = "dev"
+	Commit = "none"
+	Date = "unknown"
+	readBuildInfo = func() (*debug.BuildInfo, bool) {
+		return &debug.BuildInfo{
+			Main: debug.Module{Version: "(devel)"},
+		}, true
+	}
+
+	got := Current()
+
+	if got.Version != "dev" {
+		t.Fatalf("expected dev version for local builds, got %q", got.Version)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Derive CLI version from Go build metadata when ldflags are not provided.
- Keep GoReleaser ldflags as the preferred release metadata source.
- Fill commit and build date from VCS build settings when available.

## Why

`go install github.com/galax-io/galaxio-cli/cmd/galaxio@latest` does not run our GoReleaser ldflags, so installed binaries could report `dev`. This fallback lets module-version installs report the tagged version.

## Validation

- `go test ./...`
- `go vet ./...`
- `go test -race -coverprofile=coverage.out ./...`
- Local coverage threshold check: `coverage 92.6% meets required 30.0%`
- `go build -o bin/galaxio ./cmd/galaxio && ./bin/galaxio version`
- `go build -ldflags "-X github.com/galax-io/galaxio-cli/internal/buildinfo.Version=v2.3.4 -X github.com/galax-io/galaxio-cli/internal/buildinfo.Commit=test -X github.com/galax-io/galaxio-cli/internal/buildinfo.Date=2026-04-29T00:00:00Z" -o bin/galaxio ./cmd/galaxio && ./bin/galaxio version`
