### PR TITLE
feat: add self update command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ by GoReleaser when a `v*` tag is pushed.
 
 ## Unreleased
 
+- Add self-update support from GitHub Releases.
 - Bootstrap minimal enterprise-style CLI.
 - Add version output, minimal help, stable exit-code mapping, and global
   `--no-color`, `--verbose`, and `--quiet` flags.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@ galaxio completion fish
 galaxio completion powershell
 ```
 
+Update `galaxio` from GitHub Releases:
+
+```sh
+galaxio update
+galaxio update --dry-run
+galaxio update --version 0.1.1
+```
+
 ## Exit Codes
 
 `galaxio` keeps exit codes stable for scripts and CI:

--- a/cmd/galaxio/root.go
+++ b/cmd/galaxio/root.go
@@ -45,6 +45,7 @@ func newRootCommand() *cobra.Command {
 	cmd.PersistentFlags().BoolVarP(&opts.verbose, "verbose", "v", false, "enable verbose diagnostic output")
 	cmd.PersistentFlags().BoolVarP(&opts.quiet, "quiet", "q", false, "suppress non-essential output")
 
+	cmd.AddCommand(newUpdateCommand())
 	cmd.AddCommand(newVersionCommand())
 
 	return cmd

--- a/cmd/galaxio/root_test.go
+++ b/cmd/galaxio/root_test.go
@@ -27,10 +27,24 @@ func TestHelpPrintsMinimalUsage(t *testing.T) {
 	if stderr != "" {
 		t.Fatalf("expected empty stderr, got %q", stderr)
 	}
-	for _, want := range []string{"Enterprise command-line toolkit", "Usage:", "galaxio [flags]", "completion", "version"} {
+	for _, want := range []string{"Enterprise command-line toolkit", "Usage:", "galaxio [flags]", "completion", "update", "version"} {
 		if !strings.Contains(stdout, want) {
 			t.Fatalf("expected help output to contain %q, got %q", want, stdout)
 		}
+	}
+}
+
+func TestUpdateCommandRejectsArguments(t *testing.T) {
+	code, stdout, stderr := runCLI("update", "unexpected")
+
+	if code != exitUsage {
+		t.Fatalf("expected exit code %d, got %d", exitUsage, code)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "unknown command") {
+		t.Fatalf("expected argument validation error, got %q", stderr)
 	}
 }
 

--- a/cmd/galaxio/update.go
+++ b/cmd/galaxio/update.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/galax-io/galaxio-cli/internal/selfupdate"
+	"github.com/spf13/cobra"
+)
+
+type updateOptions struct {
+	repo    string
+	version string
+	dryRun  bool
+}
+
+func newUpdateCommand() *cobra.Command {
+	opts := &updateOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "update",
+		Short: "Update galaxio to a newer release.",
+		Long:  "Update galaxio by downloading a verified binary from GitHub Releases.",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if err := cobra.NoArgs(cmd, args); err != nil {
+				return UsageError{Err: err}
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			executable, err := os.Executable()
+			if err != nil {
+				return RuntimeError{Err: fmt.Errorf("resolve executable path: %w", err)}
+			}
+
+			result, err := selfupdate.Updater{}.Run(cmd.Context(), selfupdate.Options{
+				Repo:           opts.repo,
+				TargetVersion:  opts.version,
+				CurrentVersion: versionInfo().CleanVersion(),
+				Executable:     executable,
+				DryRun:         opts.dryRun,
+			})
+			if err != nil {
+				return RuntimeError{Err: err}
+			}
+
+			if err := printUpdateResult(cmd, result); err != nil {
+				return RuntimeError{Err: err}
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&opts.repo, "repo", "galax-io/galaxio-cli", "GitHub repository to update from")
+	cmd.Flags().StringVar(&opts.version, "version", "", "target version to install")
+	cmd.Flags().BoolVar(&opts.dryRun, "dry-run", false, "check for an update without installing it")
+
+	return cmd
+}
+
+func printUpdateResult(cmd *cobra.Command, result selfupdate.Result) error {
+	switch {
+	case result.Updated:
+		_, err := fmt.Fprintf(cmd.OutOrStdout(), "Updated galaxio from %s to %s\n", result.CurrentVersion, result.TargetVersion)
+		return err
+	case result.DryRun && result.AssetName != "":
+		_, err := fmt.Fprintf(cmd.OutOrStdout(), "Update available: %s -> %s (%s)\n", result.CurrentVersion, result.TargetVersion, result.AssetName)
+		return err
+	case result.DryRun:
+		_, err := fmt.Fprintf(cmd.OutOrStdout(), "galaxio is already up to date (%s)\n", result.CurrentVersion)
+		return err
+	default:
+		_, err := fmt.Fprintf(cmd.OutOrStdout(), "galaxio is already up to date (%s)\n", result.CurrentVersion)
+		return err
+	}
+}

--- a/internal/selfupdate/selfupdate.go
+++ b/internal/selfupdate/selfupdate.go
@@ -1,0 +1,329 @@
+// Package selfupdate updates a running galaxio binary from GitHub Releases.
+package selfupdate
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+const (
+	defaultAPIBase = "https://api.github.com"
+	binaryName     = "galaxio"
+)
+
+// Options configures a self-update run.
+type Options struct {
+	Repo           string
+	TargetVersion  string
+	CurrentVersion string
+	Executable     string
+	GOOS           string
+	GOARCH         string
+	APIBase        string
+	DryRun         bool
+}
+
+// Result describes the outcome of a self-update run.
+type Result struct {
+	CurrentVersion string
+	TargetVersion  string
+	Updated        bool
+	DryRun         bool
+	AssetName      string
+}
+
+// Updater updates galaxio from GitHub Releases.
+type Updater struct {
+	HTTPClient *http.Client
+}
+
+type release struct {
+	TagName string  `json:"tag_name"`
+	Assets  []asset `json:"assets"`
+}
+
+type asset struct {
+	Name               string `json:"name"`
+	BrowserDownloadURL string `json:"browser_download_url"`
+}
+
+// Run checks for a release and installs it when an update is available.
+func (u Updater) Run(ctx context.Context, opts Options) (Result, error) {
+	opts = opts.withDefaults()
+
+	current := cleanVersion(opts.CurrentVersion)
+	rel, err := u.fetchRelease(ctx, opts)
+	if err != nil {
+		return Result{}, err
+	}
+
+	target := cleanVersion(rel.TagName)
+	result := Result{
+		CurrentVersion: current,
+		TargetVersion:  target,
+		DryRun:         opts.DryRun,
+	}
+
+	if current != "" && current == target {
+		return result, nil
+	}
+
+	archiveAsset, err := findAsset(rel.Assets, archiveName(target, opts.GOOS, opts.GOARCH))
+	if err != nil {
+		return Result{}, err
+	}
+	result.AssetName = archiveAsset.Name
+
+	if opts.DryRun {
+		return result, nil
+	}
+
+	checksumAsset, err := findAsset(rel.Assets, "checksums.txt")
+	if err != nil {
+		return Result{}, err
+	}
+
+	archiveBytes, err := u.download(ctx, archiveAsset.BrowserDownloadURL)
+	if err != nil {
+		return Result{}, fmt.Errorf("download release asset: %w", err)
+	}
+
+	checksumBytes, err := u.download(ctx, checksumAsset.BrowserDownloadURL)
+	if err != nil {
+		return Result{}, fmt.Errorf("download checksums: %w", err)
+	}
+
+	if err := verifyChecksum(archiveAsset.Name, archiveBytes, string(checksumBytes)); err != nil {
+		return Result{}, err
+	}
+
+	binaryBytes, err := extractBinary(archiveAsset.Name, archiveBytes, executableName(opts.GOOS))
+	if err != nil {
+		return Result{}, err
+	}
+
+	if err := installBinary(opts.Executable, binaryBytes); err != nil {
+		return Result{}, err
+	}
+
+	result.Updated = true
+	return result, nil
+}
+
+func (opts Options) withDefaults() Options {
+	if opts.Repo == "" {
+		opts.Repo = "galax-io/galaxio-cli"
+	}
+	if opts.GOOS == "" {
+		opts.GOOS = runtime.GOOS
+	}
+	if opts.GOARCH == "" {
+		opts.GOARCH = runtime.GOARCH
+	}
+	if opts.APIBase == "" {
+		opts.APIBase = defaultAPIBase
+	}
+	return opts
+}
+
+func (u Updater) fetchRelease(ctx context.Context, opts Options) (release, error) {
+	endpoint := strings.TrimRight(opts.APIBase, "/") + "/repos/" + opts.Repo + "/releases/latest"
+	if opts.TargetVersion != "" {
+		endpoint = strings.TrimRight(opts.APIBase, "/") + "/repos/" + opts.Repo + "/releases/tags/v" + cleanVersion(opts.TargetVersion)
+	}
+
+	payload, err := u.download(ctx, endpoint)
+	if err != nil {
+		return release{}, fmt.Errorf("fetch release metadata: %w", err)
+	}
+
+	var rel release
+	if err := json.Unmarshal(payload, &rel); err != nil {
+		return release{}, fmt.Errorf("decode release metadata: %w", err)
+	}
+	if rel.TagName == "" {
+		return release{}, errors.New("release metadata is missing tag_name")
+	}
+
+	return rel, nil
+}
+
+func (u Updater) download(ctx context.Context, url string) ([]byte, error) {
+	client := u.HTTPClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/octet-stream")
+	req.Header.Set("User-Agent", "galaxio-cli")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return nil, fmt.Errorf("GET %s returned %s", url, resp.Status)
+	}
+
+	return io.ReadAll(resp.Body)
+}
+
+func findAsset(assets []asset, name string) (asset, error) {
+	for _, item := range assets {
+		if item.Name == name {
+			return item, nil
+		}
+	}
+	return asset{}, fmt.Errorf("release asset %q not found", name)
+}
+
+func archiveName(version string, goos string, goarch string) string {
+	extension := ".tar.gz"
+	if goos == "windows" {
+		extension = ".zip"
+	}
+	return fmt.Sprintf("galaxio_%s_%s_%s%s", cleanVersion(version), goos, goarch, extension)
+}
+
+func executableName(goos string) string {
+	if goos == "windows" {
+		return binaryName + ".exe"
+	}
+	return binaryName
+}
+
+func cleanVersion(version string) string {
+	return strings.TrimPrefix(strings.TrimSpace(version), "v")
+}
+
+func verifyChecksum(assetName string, payload []byte, checksums string) error {
+	want := ""
+	for _, line := range strings.Split(checksums, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) != 2 {
+			continue
+		}
+		if fields[1] == assetName {
+			want = fields[0]
+			break
+		}
+	}
+	if want == "" {
+		return fmt.Errorf("checksum for %q not found", assetName)
+	}
+
+	sum := sha256.Sum256(payload)
+	got := hex.EncodeToString(sum[:])
+	if !strings.EqualFold(got, want) {
+		return fmt.Errorf("checksum mismatch for %q", assetName)
+	}
+
+	return nil
+}
+
+func extractBinary(assetName string, payload []byte, executable string) ([]byte, error) {
+	switch {
+	case strings.HasSuffix(assetName, ".tar.gz"):
+		return extractBinaryFromTarGzip(payload, executable)
+	case strings.HasSuffix(assetName, ".zip"):
+		return extractBinaryFromZip(payload, executable)
+	default:
+		return nil, fmt.Errorf("unsupported archive format %q", assetName)
+	}
+}
+
+func extractBinaryFromTarGzip(payload []byte, executable string) ([]byte, error) {
+	gzipReader, err := gzip.NewReader(bytes.NewReader(payload))
+	if err != nil {
+		return nil, err
+	}
+	defer gzipReader.Close()
+
+	tarReader := tar.NewReader(gzipReader)
+	for {
+		header, err := tarReader.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		if filepath.Base(header.Name) != executable {
+			continue
+		}
+		return io.ReadAll(tarReader)
+	}
+
+	return nil, fmt.Errorf("binary %q not found in archive", executable)
+}
+
+func extractBinaryFromZip(payload []byte, executable string) ([]byte, error) {
+	reader, err := zip.NewReader(bytes.NewReader(payload), int64(len(payload)))
+	if err != nil {
+		return nil, err
+	}
+
+	for _, file := range reader.File {
+		if filepath.Base(file.Name) != executable {
+			continue
+		}
+
+		item, err := file.Open()
+		if err != nil {
+			return nil, err
+		}
+		defer item.Close()
+
+		return io.ReadAll(item)
+	}
+
+	return nil, fmt.Errorf("binary %q not found in archive", executable)
+}
+
+func installBinary(executable string, payload []byte) error {
+	if executable == "" {
+		return errors.New("executable path is required")
+	}
+
+	dir := filepath.Dir(executable)
+	temp, err := os.CreateTemp(dir, ".galaxio-update-*")
+	if err != nil {
+		return err
+	}
+	tempName := temp.Name()
+	defer os.Remove(tempName)
+
+	if _, err := temp.Write(payload); err != nil {
+		_ = temp.Close()
+		return err
+	}
+	if err := temp.Chmod(0o755); err != nil {
+		_ = temp.Close()
+		return err
+	}
+	if err := temp.Close(); err != nil {
+		return err
+	}
+
+	return os.Rename(tempName, executable)
+}

--- a/internal/selfupdate/selfupdate_test.go
+++ b/internal/selfupdate/selfupdate_test.go
@@ -1,0 +1,263 @@
+package selfupdate
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunDryRunFindsAvailableUpdate(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/repos/galax-io/galaxio-cli/releases/latest" {
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+		fmt.Fprintf(w, `{
+			"tag_name":"v1.2.3",
+			"assets":[
+				{"name":"galaxio_1.2.3_linux_amd64.tar.gz","browser_download_url":"%s/archive"}
+			]
+		}`, serverURL(r))
+	}))
+	defer server.Close()
+
+	result, err := Updater{HTTPClient: server.Client()}.Run(context.Background(), Options{
+		APIBase:        server.URL,
+		CurrentVersion: "1.2.2",
+		GOOS:           "linux",
+		GOARCH:         "amd64",
+		DryRun:         true,
+	})
+
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if result.Updated {
+		t.Fatal("expected dry run not to update")
+	}
+	if result.TargetVersion != "1.2.3" {
+		t.Fatalf("expected target version 1.2.3, got %q", result.TargetVersion)
+	}
+	if result.AssetName != "galaxio_1.2.3_linux_amd64.tar.gz" {
+		t.Fatalf("expected selected asset name, got %q", result.AssetName)
+	}
+}
+
+func TestRunSkipsCurrentVersion(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"tag_name":"v1.2.3","assets":[]}`))
+	}))
+	defer server.Close()
+
+	result, err := Updater{HTTPClient: server.Client()}.Run(context.Background(), Options{
+		APIBase:        server.URL,
+		CurrentVersion: "1.2.3",
+		DryRun:         true,
+	})
+
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if result.Updated {
+		t.Fatal("expected no update")
+	}
+	if result.AssetName != "" {
+		t.Fatalf("expected no asset selection, got %q", result.AssetName)
+	}
+}
+
+func TestRunInstallsVerifiedArchive(t *testing.T) {
+	const assetName = "galaxio_1.2.3_linux_amd64.tar.gz"
+	archivePayload := tarGzipArchive(t, "galaxio", "new binary")
+	checksum := sha256.Sum256(archivePayload)
+	checksums := hex.EncodeToString(checksum[:]) + "  " + assetName + "\n"
+
+	executable := filepath.Join(t.TempDir(), "galaxio")
+	if err := os.WriteFile(executable, []byte("old binary"), 0o755); err != nil {
+		t.Fatalf("write executable: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/galax-io/galaxio-cli/releases/latest":
+			fmt.Fprintf(w, `{
+				"tag_name":"v1.2.3",
+				"assets":[
+					{"name":"%s","browser_download_url":"%s/archive"},
+					{"name":"checksums.txt","browser_download_url":"%s/checksums.txt"}
+				]
+			}`, assetName, serverURL(r), serverURL(r))
+		case "/archive":
+			_, _ = w.Write(archivePayload)
+		case "/checksums.txt":
+			_, _ = w.Write([]byte(checksums))
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	result, err := Updater{HTTPClient: server.Client()}.Run(context.Background(), Options{
+		APIBase:        server.URL,
+		CurrentVersion: "1.2.2",
+		Executable:     executable,
+		GOOS:           "linux",
+		GOARCH:         "amd64",
+	})
+
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !result.Updated {
+		t.Fatal("expected update to be installed")
+	}
+
+	got, err := os.ReadFile(executable)
+	if err != nil {
+		t.Fatalf("read executable: %v", err)
+	}
+	if string(got) != "new binary" {
+		t.Fatalf("expected updated binary, got %q", got)
+	}
+}
+
+func TestRunRejectsChecksumMismatch(t *testing.T) {
+	const assetName = "galaxio_1.2.3_linux_amd64.tar.gz"
+	archivePayload := tarGzipArchive(t, "galaxio", "new binary")
+	checksums := strings.Repeat("0", 64) + "  " + assetName + "\n"
+	executable := filepath.Join(t.TempDir(), "galaxio")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/galax-io/galaxio-cli/releases/latest":
+			fmt.Fprintf(w, `{
+				"tag_name":"v1.2.3",
+				"assets":[
+					{"name":"%s","browser_download_url":"%s/archive"},
+					{"name":"checksums.txt","browser_download_url":"%s/checksums.txt"}
+				]
+			}`, assetName, serverURL(r), serverURL(r))
+		case "/archive":
+			_, _ = w.Write(archivePayload)
+		case "/checksums.txt":
+			_, _ = w.Write([]byte(checksums))
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	_, err := Updater{HTTPClient: server.Client()}.Run(context.Background(), Options{
+		APIBase:        server.URL,
+		CurrentVersion: "1.2.2",
+		Executable:     executable,
+		GOOS:           "linux",
+		GOARCH:         "amd64",
+	})
+
+	if err == nil {
+		t.Fatal("expected checksum error")
+	}
+	if !strings.Contains(err.Error(), "checksum mismatch") {
+		t.Fatalf("expected checksum mismatch error, got %v", err)
+	}
+}
+
+func TestRunUsesRequestedVersionEndpoint(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/repos/galax-io/galaxio-cli/releases/tags/v1.2.3" {
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+		_, _ = w.Write([]byte(`{
+			"tag_name":"v1.2.3",
+			"assets":[{"name":"galaxio_1.2.3_darwin_arm64.tar.gz","browser_download_url":"https://example.invalid/archive"}]
+		}`))
+	}))
+	defer server.Close()
+
+	_, err := Updater{HTTPClient: server.Client()}.Run(context.Background(), Options{
+		APIBase:        server.URL,
+		TargetVersion:  "1.2.3",
+		CurrentVersion: "1.2.2",
+		GOOS:           "darwin",
+		GOARCH:         "arm64",
+		DryRun:         true,
+	})
+
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestExtractBinaryFromZip(t *testing.T) {
+	payload := zipArchive(t, "galaxio.exe", "windows binary")
+
+	got, err := extractBinary("galaxio_1.2.3_windows_amd64.zip", payload, "galaxio.exe")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if string(got) != "windows binary" {
+		t.Fatalf("expected extracted payload, got %q", got)
+	}
+}
+
+func serverURL(r *http.Request) string {
+	return "http://" + r.Host
+}
+
+func tarGzipArchive(t *testing.T, name string, body string) []byte {
+	t.Helper()
+
+	var buffer bytes.Buffer
+	gzipWriter := gzip.NewWriter(&buffer)
+	tarWriter := tar.NewWriter(gzipWriter)
+
+	payload := []byte(body)
+	if err := tarWriter.WriteHeader(&tar.Header{
+		Name: name,
+		Mode: 0o755,
+		Size: int64(len(payload)),
+	}); err != nil {
+		t.Fatalf("write tar header: %v", err)
+	}
+	if _, err := tarWriter.Write(payload); err != nil {
+		t.Fatalf("write tar payload: %v", err)
+	}
+	if err := tarWriter.Close(); err != nil {
+		t.Fatalf("close tar: %v", err)
+	}
+	if err := gzipWriter.Close(); err != nil {
+		t.Fatalf("close gzip: %v", err)
+	}
+
+	return buffer.Bytes()
+}
+
+func zipArchive(t *testing.T, name string, body string) []byte {
+	t.Helper()
+
+	var buffer bytes.Buffer
+	writer := zip.NewWriter(&buffer)
+	file, err := writer.Create(name)
+	if err != nil {
+		t.Fatalf("create zip file: %v", err)
+	}
+	if _, err := file.Write([]byte(body)); err != nil {
+		t.Fatalf("write zip payload: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close zip: %v", err)
+	}
+
+	return buffer.Bytes()
+}


### PR DESCRIPTION
## Summary

- Add `galaxio update` for self-updating from GitHub Releases.
- Support `--dry-run`, `--version`, and `--repo` flags.
- Verify downloaded release archives against `checksums.txt` before installation.
- Support GoReleaser `tar.gz` archives for Unix and `zip` archives for Windows.
- Document update usage in README and CHANGELOG.

## Notes

- This PR is independent from #3, but #3 should be merged before the next release so `go install ...@version` reports the correct current version.
- `galaxio update` expects GoReleaser release assets named like `galaxio_0.1.1_darwin_arm64.tar.gz` plus `checksums.txt`.

## Validation

- `go test ./...`
- `go vet ./...`
- `go test -race -coverprofile=coverage.out ./...`
- Local coverage threshold check: `coverage 72.3% meets required 30.0%`
- `go build -trimpath -o dist/galaxio ./cmd/galaxio && ./dist/galaxio update --help`
- `go mod tidy && git diff --exit-code -- go.mod go.sum`
