### PR TITLE
fix: use github json api for self update

### DIFF
--- a/internal/selfupdate/selfupdate.go
+++ b/internal/selfupdate/selfupdate.go
@@ -78,7 +78,7 @@ func (u Updater) Run(ctx context.Context, opts Options) (Result, error) {
 		DryRun:         opts.DryRun,
 	}
 
-	if current != "" && current == target {
+	if !isNewerVersion(current, target) {
 		return result, nil
 	}
 
@@ -146,7 +146,7 @@ func (u Updater) fetchRelease(ctx context.Context, opts Options) (release, error
 		endpoint = strings.TrimRight(opts.APIBase, "/") + "/repos/" + opts.Repo + "/releases/tags/v" + cleanVersion(opts.TargetVersion)
 	}
 
-	payload, err := u.download(ctx, endpoint)
+	payload, err := u.downloadJSON(ctx, endpoint)
 	if err != nil {
 		return release{}, fmt.Errorf("fetch release metadata: %w", err)
 	}
@@ -163,6 +163,19 @@ func (u Updater) fetchRelease(ctx context.Context, opts Options) (release, error
 }
 
 func (u Updater) download(ctx context.Context, url string) ([]byte, error) {
+	return u.downloadWithHeaders(ctx, url, map[string]string{
+		"Accept": "application/octet-stream",
+	})
+}
+
+func (u Updater) downloadJSON(ctx context.Context, url string) ([]byte, error) {
+	return u.downloadWithHeaders(ctx, url, map[string]string{
+		"Accept":               "application/vnd.github+json",
+		"X-GitHub-Api-Version": "2022-11-28",
+	})
+}
+
+func (u Updater) downloadWithHeaders(ctx context.Context, url string, headers map[string]string) ([]byte, error) {
 	client := u.HTTPClient
 	if client == nil {
 		client = http.DefaultClient
@@ -172,8 +185,10 @@ func (u Updater) download(ctx context.Context, url string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("Accept", "application/octet-stream")
 	req.Header.Set("User-Agent", "galaxio-cli")
+	for key, value := range headers {
+		req.Header.Set(key, value)
+	}
 
 	resp, err := client.Do(req)
 	if err != nil {
@@ -182,6 +197,9 @@ func (u Updater) download(ctx context.Context, url string) ([]byte, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		if resp.StatusCode == http.StatusNotFound {
+			return nil, fmt.Errorf("GET %s returned %s; release was not found or repository is not accessible", url, resp.Status)
+		}
 		return nil, fmt.Errorf("GET %s returned %s", url, resp.Status)
 	}
 
@@ -214,6 +232,59 @@ func executableName(goos string) string {
 
 func cleanVersion(version string) string {
 	return strings.TrimPrefix(strings.TrimSpace(version), "v")
+}
+
+func isNewerVersion(current string, target string) bool {
+	if current == "" {
+		return target != ""
+	}
+
+	currentParts, currentOK := versionParts(current)
+	targetParts, targetOK := versionParts(target)
+	if !currentOK || !targetOK {
+		return current != target
+	}
+
+	for i := range targetParts {
+		if targetParts[i] > currentParts[i] {
+			return true
+		}
+		if targetParts[i] < currentParts[i] {
+			return false
+		}
+	}
+
+	return false
+}
+
+func versionParts(version string) ([3]int, bool) {
+	var parts [3]int
+	version = cleanVersion(version)
+	if before, _, ok := strings.Cut(version, "-"); ok {
+		version = before
+	}
+	if before, _, ok := strings.Cut(version, "+"); ok {
+		version = before
+	}
+
+	items := strings.Split(version, ".")
+	if len(items) != 3 {
+		return parts, false
+	}
+
+	for index, item := range items {
+		if item == "" {
+			return parts, false
+		}
+		for _, char := range item {
+			if char < '0' || char > '9' {
+				return parts, false
+			}
+			parts[index] = parts[index]*10 + int(char-'0')
+		}
+	}
+
+	return parts, true
 }
 
 func verifyChecksum(assetName string, payload []byte, checksums string) error {

--- a/internal/selfupdate/selfupdate_test.go
+++ b/internal/selfupdate/selfupdate_test.go
@@ -22,6 +22,9 @@ func TestRunDryRunFindsAvailableUpdate(t *testing.T) {
 		if r.URL.Path != "/repos/galax-io/galaxio-cli/releases/latest" {
 			t.Fatalf("unexpected path %s", r.URL.Path)
 		}
+		if got := r.Header.Get("Accept"); got != "application/vnd.github+json" {
+			t.Fatalf("expected GitHub JSON accept header, got %q", got)
+		}
 		fmt.Fprintf(w, `{
 			"tag_name":"v1.2.3",
 			"assets":[
@@ -62,6 +65,29 @@ func TestRunSkipsCurrentVersion(t *testing.T) {
 	result, err := Updater{HTTPClient: server.Client()}.Run(context.Background(), Options{
 		APIBase:        server.URL,
 		CurrentVersion: "1.2.3",
+		DryRun:         true,
+	})
+
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if result.Updated {
+		t.Fatal("expected no update")
+	}
+	if result.AssetName != "" {
+		t.Fatalf("expected no asset selection, got %q", result.AssetName)
+	}
+}
+
+func TestRunSkipsOlderRelease(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"tag_name":"v1.2.3","assets":[]}`))
+	}))
+	defer server.Close()
+
+	result, err := Updater{HTTPClient: server.Client()}.Run(context.Background(), Options{
+		APIBase:        server.URL,
+		CurrentVersion: "1.2.4-0.20260429122805-b25dd5b9f28b+dirty",
 		DryRun:         true,
 	})
 
@@ -196,6 +222,48 @@ func TestRunUsesRequestedVersionEndpoint(t *testing.T) {
 
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestIsNewerVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		current string
+		target  string
+		want    bool
+	}{
+		{name: "newer patch", current: "1.2.3", target: "1.2.4", want: true},
+		{name: "same version", current: "1.2.3", target: "v1.2.3", want: false},
+		{name: "older target", current: "1.2.4", target: "1.2.3", want: false},
+		{name: "build metadata ignored", current: "1.2.3+dirty", target: "1.2.3", want: false},
+		{name: "pseudo version core", current: "1.2.4-0.20260429122805-b25dd5b9f28b+dirty", target: "1.2.3", want: false},
+		{name: "unknown current", current: "dev", target: "1.2.3", want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isNewerVersion(tt.current, tt.target); got != tt.want {
+				t.Fatalf("expected %v, got %v", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestRunExplainsReleaseNotFound(t *testing.T) {
+	server := httptest.NewServer(http.NotFoundHandler())
+	defer server.Close()
+
+	_, err := Updater{HTTPClient: server.Client()}.Run(context.Background(), Options{
+		APIBase:        server.URL,
+		CurrentVersion: "1.2.2",
+		DryRun:         true,
+	})
+
+	if err == nil {
+		t.Fatal("expected not found error")
+	}
+	if !strings.Contains(err.Error(), "release was not found or repository is not accessible") {
+		t.Fatalf("expected actionable not found error, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Use GitHub JSON media type for release metadata requests instead of `application/octet-stream`.
- Return a clearer 404 message when the release is not found or the repository is not accessible.
- Avoid offering a downgrade when the latest release is older than the current build metadata.
- Add tests for GitHub headers, 404 messaging, and version ordering.

## Validation

- `go test ./...`
- `go vet ./...`
- `go test -race -coverprofile=coverage.out ./...`
- Local coverage threshold check: `coverage 77.4% meets required 30.0%`
- `go build -trimpath -o bin/galaxio ./cmd/galaxio`
- `./bin/galaxio update --dry-run` confirms unauthenticated inaccessible release now returns a clear 404/accessibility error, not 415.
