### PR TITLE
feat: add template registry discovery

### DIFF
--- a/cmd/galaxio/doctor.go
+++ b/cmd/galaxio/doctor.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/galax-io/galaxio-cli/internal/templatecatalog"
+	"github.com/spf13/cobra"
+)
+
+func newDoctorCommand() *cobra.Command {
+	var registry string
+
+	cmd := &cobra.Command{
+		Use:   "doctor",
+		Short: "Check galaxio configuration and dependencies.",
+		Long:  "Check galaxio configuration, template registry access, and template pack manifests.",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if err := cobra.NoArgs(cmd, args); err != nil {
+				return UsageError{Err: err}
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fetcher := templatecatalog.SourceFetcher{}
+			templates, err := fetcher.ListPacks(cmd.Context(), registry)
+			if err != nil {
+				return RuntimeError{Err: err}
+			}
+
+			_, err = fmt.Fprintf(cmd.OutOrStdout(), "OK template registry: %s\n", registry)
+			if err != nil {
+				return RuntimeError{Err: err}
+			}
+			_, err = fmt.Fprintf(cmd.OutOrStdout(), "OK template entries: %d\n", len(templates))
+			if err != nil {
+				return RuntimeError{Err: err}
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&registry, "registry", templatecatalog.DefaultRegistrySource, "template registry source")
+
+	return cmd
+}

--- a/cmd/galaxio/root.go
+++ b/cmd/galaxio/root.go
@@ -45,6 +45,7 @@ func newRootCommand() *cobra.Command {
 	cmd.PersistentFlags().BoolVarP(&opts.verbose, "verbose", "v", false, "enable verbose diagnostic output")
 	cmd.PersistentFlags().BoolVarP(&opts.quiet, "quiet", "q", false, "suppress non-essential output")
 
+	cmd.AddCommand(newDoctorCommand())
 	cmd.AddCommand(newTemplateCommand())
 	cmd.AddCommand(newUpdateCommand())
 	cmd.AddCommand(newVersionCommand())

--- a/cmd/galaxio/root.go
+++ b/cmd/galaxio/root.go
@@ -45,6 +45,7 @@ func newRootCommand() *cobra.Command {
 	cmd.PersistentFlags().BoolVarP(&opts.verbose, "verbose", "v", false, "enable verbose diagnostic output")
 	cmd.PersistentFlags().BoolVarP(&opts.quiet, "quiet", "q", false, "suppress non-essential output")
 
+	cmd.AddCommand(newTemplateCommand())
 	cmd.AddCommand(newUpdateCommand())
 	cmd.AddCommand(newVersionCommand())
 

--- a/cmd/galaxio/root_test.go
+++ b/cmd/galaxio/root_test.go
@@ -27,10 +27,24 @@ func TestHelpPrintsMinimalUsage(t *testing.T) {
 	if stderr != "" {
 		t.Fatalf("expected empty stderr, got %q", stderr)
 	}
-	for _, want := range []string{"Enterprise command-line toolkit", "Usage:", "galaxio [flags]", "completion", "template", "update", "version"} {
+	for _, want := range []string{"Enterprise command-line toolkit", "Usage:", "galaxio [flags]", "completion", "doctor", "template", "update", "version"} {
 		if !strings.Contains(stdout, want) {
 			t.Fatalf("expected help output to contain %q, got %q", want, stdout)
 		}
+	}
+}
+
+func TestDoctorRejectsArguments(t *testing.T) {
+	code, stdout, stderr := runCLI("doctor", "unexpected")
+
+	if code != exitUsage {
+		t.Fatalf("expected exit code %d, got %d", exitUsage, code)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "unknown command") && !strings.Contains(stderr, "accepts 0 arg") {
+		t.Fatalf("expected argument validation error, got %q", stderr)
 	}
 }
 

--- a/cmd/galaxio/root_test.go
+++ b/cmd/galaxio/root_test.go
@@ -27,10 +27,54 @@ func TestHelpPrintsMinimalUsage(t *testing.T) {
 	if stderr != "" {
 		t.Fatalf("expected empty stderr, got %q", stderr)
 	}
-	for _, want := range []string{"Enterprise command-line toolkit", "Usage:", "galaxio [flags]", "completion", "update", "version"} {
+	for _, want := range []string{"Enterprise command-line toolkit", "Usage:", "galaxio [flags]", "completion", "template", "update", "version"} {
 		if !strings.Contains(stdout, want) {
 			t.Fatalf("expected help output to contain %q, got %q", want, stdout)
 		}
+	}
+}
+
+func TestTemplateCommandPrintsHelp(t *testing.T) {
+	code, stdout, stderr := runCLI("template", "--help")
+
+	if code != exitOK {
+		t.Fatalf("expected exit code %d, got %d", exitOK, code)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	for _, want := range []string{"Discover and validate", "init", "list", "validate"} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("expected template help to contain %q, got %q", want, stdout)
+		}
+	}
+}
+
+func TestTemplateInitPrintsComingSoon(t *testing.T) {
+	code, stdout, stderr := runCLI("template", "init", "gatling/scala-sbt")
+
+	if code != exitOK {
+		t.Fatalf("expected exit code %d, got %d", exitOK, code)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if want := "Template gatling/scala-sbt is coming soon"; !strings.Contains(stdout, want) {
+		t.Fatalf("expected coming soon output %q, got %q", want, stdout)
+	}
+}
+
+func TestTemplateValidateRequiresSource(t *testing.T) {
+	code, stdout, stderr := runCLI("template", "validate")
+
+	if code != exitUsage {
+		t.Fatalf("expected exit code %d, got %d", exitUsage, code)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "accepts 1 arg") {
+		t.Fatalf("expected argument validation error, got %q", stderr)
 	}
 }
 

--- a/cmd/galaxio/template.go
+++ b/cmd/galaxio/template.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/galax-io/galaxio-cli/internal/templatecatalog"
+	"github.com/spf13/cobra"
+)
+
+func newTemplateCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "template",
+		Short: "Discover and validate project templates.",
+		Long:  "Discover and validate project templates from Galaxio template registries.",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if err := cobra.NoArgs(cmd, args); err != nil {
+				return UsageError{Err: err}
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+
+	cmd.AddCommand(newTemplateListCommand())
+	cmd.AddCommand(newTemplateInitCommand())
+	cmd.AddCommand(newTemplateValidateCommand())
+
+	return cmd
+}
+
+func newTemplateListCommand() *cobra.Command {
+	var registry string
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List available templates.",
+		Long:  "List templates from a Galaxio template registry.",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if err := cobra.NoArgs(cmd, args); err != nil {
+				return UsageError{Err: err}
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			packs, err := (templatecatalog.SourceFetcher{}).ListPacks(cmd.Context(), registry)
+			if err != nil {
+				return RuntimeError{Err: err}
+			}
+
+			for _, pack := range packs {
+				state := "available"
+				if pack.Placeholder {
+					state = "coming soon"
+				}
+				if pack.Description == "" {
+					_, err = fmt.Fprintf(cmd.OutOrStdout(), "%s\t%s\t%s\n", pack.Name, state, pack.Source)
+				} else {
+					_, err = fmt.Fprintf(cmd.OutOrStdout(), "%s\t%s\t%s\t%s\n", pack.Name, state, pack.Source, pack.Description)
+				}
+				if err != nil {
+					return RuntimeError{Err: err}
+				}
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&registry, "registry", templatecatalog.DefaultRegistrySource, "template registry source")
+
+	return cmd
+}
+
+func newTemplateInitCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "init <template>",
+		Short: "Initialize a project from a template.",
+		Long:  "Initialize a project from a template. Rendering support is not available yet.",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if err := cobra.ExactArgs(1)(cmd, args); err != nil {
+				return UsageError{Err: err}
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			_, err := fmt.Fprintf(cmd.OutOrStdout(), "Template %s is coming soon\n", args[0])
+			if err != nil {
+				return RuntimeError{Err: err}
+			}
+			return nil
+		},
+	}
+
+	return cmd
+}
+
+func newTemplateValidateCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "validate <source>",
+		Short: "Validate a template pack.",
+		Long:  "Validate a Galaxio template pack and its template manifests.",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if err := cobra.ExactArgs(1)(cmd, args); err != nil {
+				return UsageError{Err: err}
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			source := args[0]
+			if err := (templatecatalog.SourceFetcher{}).ValidateSource(cmd.Context(), source); err != nil {
+				return RuntimeError{Err: err}
+			}
+
+			_, err := fmt.Fprintf(cmd.OutOrStdout(), "Template pack %s is valid\n", source)
+			if err != nil {
+				return RuntimeError{Err: err}
+			}
+
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/docs/templates/README.md
+++ b/docs/templates/README.md
@@ -1,0 +1,55 @@
+# Galaxio Templates
+
+Galaxio registries describe where the CLI can discover template packs.
+
+This first step only defines the default registry contract. Template pack and
+template rendering formats will be added separately. Commands currently operate
+at discovery and validation level, not rendering level.
+
+## Default Registry
+
+The CLI should use this registry by default:
+
+```text
+github:galax-io/galaxio-template-registry
+```
+
+Users only need `galaxio template configure --registry ...` when they want to
+override the default registry with another source.
+
+## Concepts
+
+- **Registry**: an index of template packs available to the CLI.
+- **Pack**: a repository that groups related templates. Pack structure is not
+  defined in this step.
+
+## Registry
+
+A registry points the CLI to template packs:
+
+```yaml
+apiVersion: galaxio.io/v1
+kind: TemplateRegistry
+packs:
+  - name: gatling
+    source: github:galax-io/templates-gatling
+    description: Gatling performance testing templates
+```
+
+## Planned CLI Flow
+
+```sh
+galaxio template list
+galaxio template list --registry local:../galaxio-template-registry
+galaxio template init gatling/scala-sbt
+galaxio template validate local:../templates-gatling
+galaxio template validate github:galax-io/templates-gatling
+galaxio doctor
+```
+
+Later steps will add persistent configuration and rendering:
+
+```sh
+galaxio template configure --show
+galaxio template configure --registry github:my-org/my-template-registry
+```

--- a/examples/templates/registry/galaxio-registry.yaml
+++ b/examples/templates/registry/galaxio-registry.yaml
@@ -1,0 +1,6 @@
+apiVersion: galaxio.io/v1
+kind: TemplateRegistry
+packs:
+  - name: gatling
+    source: github:galax-io/templates-gatling
+    description: Gatling performance testing templates

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,10 @@ module github.com/galax-io/galaxio-cli
 
 go 1.24.0
 
-require github.com/spf13/cobra v1.10.1
+require (
+	github.com/spf13/cobra v1.10.1
+	gopkg.in/yaml.v3 v3.0.1
+)
 
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,5 +6,7 @@ github.com/spf13/cobra v1.10.1 h1:lJeBwCfmrnXthfAupyUTzJ/J4Nc1RsHC/mSRU2dll/s=
 github.com/spf13/cobra v1.10.1/go.mod h1:7SmJGaTHFVBY0jW4NXGluQoLvhqFQM+6XSKD+P4XaB0=
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/templatecatalog/catalog.go
+++ b/internal/templatecatalog/catalog.go
@@ -1,0 +1,348 @@
+// Package templatecatalog reads and validates Galaxio template registries and
+// packs.
+package templatecatalog
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	DefaultRegistrySource = "github:galax-io/galaxio-template-registry"
+	registryFileName      = "galaxio-registry.yaml"
+	packFileName          = "galaxio-pack.yaml"
+	templateFileName      = "galaxio-template.yaml"
+)
+
+// Registry is the root index of available template packs.
+type Registry struct {
+	APIVersion string         `yaml:"apiVersion"`
+	Kind       string         `yaml:"kind"`
+	Packs      []RegistryPack `yaml:"packs"`
+}
+
+// RegistryPack describes one template pack source.
+type RegistryPack struct {
+	Name        string `yaml:"name"`
+	Source      string `yaml:"source"`
+	Description string `yaml:"description"`
+}
+
+// Pack describes templates available in one template pack repository.
+type Pack struct {
+	APIVersion  string         `yaml:"apiVersion"`
+	Kind        string         `yaml:"kind"`
+	Name        string         `yaml:"name"`
+	Version     string         `yaml:"version"`
+	Description string         `yaml:"description"`
+	Templates   []PackTemplate `yaml:"templates"`
+}
+
+// PackTemplate points to one template manifest inside a pack.
+type PackTemplate struct {
+	Name        string `yaml:"name"`
+	Path        string `yaml:"path"`
+	Description string `yaml:"description"`
+}
+
+// Template describes one renderable template.
+type Template struct {
+	APIVersion  string                 `yaml:"apiVersion"`
+	Kind        string                 `yaml:"kind"`
+	Name        string                 `yaml:"name"`
+	DisplayName string                 `yaml:"displayName"`
+	Description string                 `yaml:"description"`
+	Engine      string                 `yaml:"engine"`
+	Tags        []string               `yaml:"tags"`
+	Inputs      map[string]interface{} `yaml:"inputs"`
+	Computed    map[string]string      `yaml:"computed"`
+	Files       []TemplateFile         `yaml:"files"`
+}
+
+// TemplateFile describes one file mapping in a template.
+type TemplateFile struct {
+	From string `yaml:"from"`
+	To   string `yaml:"to"`
+}
+
+// TemplateRef is a resolved template available to users.
+type TemplateRef struct {
+	Name        string
+	Pack        string
+	Source      string
+	Description string
+	Templates   int
+	Placeholder bool
+}
+
+// SourceFetcher loads manifest files from local paths or remote sources.
+type SourceFetcher struct {
+	HTTPClient *http.Client
+}
+
+// LoadRegistry loads and validates a registry manifest from source.
+func (f SourceFetcher) LoadRegistry(ctx context.Context, source string) (Registry, error) {
+	if source == "" {
+		source = DefaultRegistrySource
+	}
+
+	payload, err := f.readManifest(ctx, source, registryFileName)
+	if err != nil {
+		return Registry{}, err
+	}
+
+	var registry Registry
+	if err := yaml.Unmarshal(payload, &registry); err != nil {
+		return Registry{}, fmt.Errorf("decode registry: %w", err)
+	}
+
+	if err := ValidateRegistry(registry); err != nil {
+		return Registry{}, err
+	}
+
+	return registry, nil
+}
+
+// LoadPack loads and validates a template pack from source.
+func (f SourceFetcher) LoadPack(ctx context.Context, source string) (Pack, error) {
+	payload, err := f.readManifest(ctx, source, packFileName)
+	if err != nil {
+		return Pack{}, err
+	}
+
+	var pack Pack
+	if err := yaml.Unmarshal(payload, &pack); err != nil {
+		return Pack{}, fmt.Errorf("decode pack: %w", err)
+	}
+
+	if err := ValidatePack(pack); err != nil {
+		return Pack{}, err
+	}
+
+	return pack, nil
+}
+
+// LoadTemplate loads and validates a template manifest from a pack source.
+func (f SourceFetcher) LoadTemplate(ctx context.Context, packSource string, templatePath string) (Template, error) {
+	payload, err := f.readManifest(ctx, joinSource(packSource, templatePath), templateFileName)
+	if err != nil {
+		return Template{}, err
+	}
+
+	var template Template
+	if err := yaml.Unmarshal(payload, &template); err != nil {
+		return Template{}, fmt.Errorf("decode template: %w", err)
+	}
+
+	if err := ValidateTemplate(template); err != nil {
+		return Template{}, err
+	}
+
+	return template, nil
+}
+
+// ListPacks reads the registry and validates referenced packs.
+func (f SourceFetcher) ListPacks(ctx context.Context, registrySource string) ([]TemplateRef, error) {
+	registry, err := f.LoadRegistry(ctx, registrySource)
+	if err != nil {
+		return nil, err
+	}
+
+	var result []TemplateRef
+	for _, registryPack := range registry.Packs {
+		pack, err := f.LoadPack(ctx, registryPack.Source)
+		if err != nil {
+			return nil, fmt.Errorf("load pack %q: %w", registryPack.Name, err)
+		}
+		for _, template := range pack.Templates {
+			result = append(result, TemplateRef{
+				Name:        pack.Name + "/" + template.Name,
+				Pack:        pack.Name,
+				Source:      registryPack.Source,
+				Description: template.Description,
+				Templates:   len(pack.Templates),
+				Placeholder: template.Path == "",
+			})
+		}
+	}
+
+	return result, nil
+}
+
+// ValidateSource validates a template pack source and its template manifests.
+func (f SourceFetcher) ValidateSource(ctx context.Context, source string) error {
+	pack, err := f.LoadPack(ctx, source)
+	if err != nil {
+		return err
+	}
+
+	for _, template := range pack.Templates {
+		if template.Path == "" {
+			continue
+		}
+		if _, err := f.LoadTemplate(ctx, source, template.Path); err != nil {
+			return fmt.Errorf("validate template %q: %w", template.Name, err)
+		}
+	}
+
+	return nil
+}
+
+// ValidateRegistry validates registry-level invariants.
+func ValidateRegistry(registry Registry) error {
+	if registry.APIVersion != "galaxio.io/v1" {
+		return fmt.Errorf("registry apiVersion must be galaxio.io/v1")
+	}
+	if registry.Kind != "TemplateRegistry" {
+		return fmt.Errorf("registry kind must be TemplateRegistry")
+	}
+	if len(registry.Packs) == 0 {
+		return fmt.Errorf("registry must contain at least one pack")
+	}
+
+	for _, pack := range registry.Packs {
+		if pack.Name == "" {
+			return fmt.Errorf("registry pack name is required")
+		}
+		if pack.Source == "" {
+			return fmt.Errorf("registry pack %q source is required", pack.Name)
+		}
+	}
+
+	return nil
+}
+
+// ValidatePack validates pack-level invariants.
+func ValidatePack(pack Pack) error {
+	if pack.APIVersion != "galaxio.io/v1" {
+		return fmt.Errorf("pack apiVersion must be galaxio.io/v1")
+	}
+	if pack.Kind != "TemplatePack" {
+		return fmt.Errorf("pack kind must be TemplatePack")
+	}
+	if pack.Name == "" {
+		return fmt.Errorf("pack name is required")
+	}
+	if pack.Version == "" {
+		return fmt.Errorf("pack version is required")
+	}
+	for _, template := range pack.Templates {
+		if template.Name == "" {
+			return fmt.Errorf("template name is required")
+		}
+		if template.Path == "" {
+			continue
+		}
+		if strings.Contains(template.Path, "..") {
+			return fmt.Errorf("template %q path must not contain '..'", template.Name)
+		}
+	}
+
+	return nil
+}
+
+// ValidateTemplate validates template-level invariants.
+func ValidateTemplate(template Template) error {
+	if template.APIVersion != "galaxio.io/v1" {
+		return fmt.Errorf("template apiVersion must be galaxio.io/v1")
+	}
+	if template.Kind != "Template" {
+		return fmt.Errorf("template kind must be Template")
+	}
+	if template.Name == "" {
+		return fmt.Errorf("template name is required")
+	}
+	if template.Engine != "go-template" {
+		return fmt.Errorf("template engine must be go-template")
+	}
+	if len(template.Inputs) == 0 {
+		return fmt.Errorf("template inputs are required")
+	}
+	if len(template.Files) == 0 {
+		return fmt.Errorf("template files are required")
+	}
+
+	return nil
+}
+
+func (f SourceFetcher) readManifest(ctx context.Context, source string, manifest string) ([]byte, error) {
+	switch {
+	case strings.HasPrefix(source, "github:"):
+		return f.readURL(ctx, githubRawURL(strings.TrimPrefix(source, "github:"), manifest))
+	case strings.HasPrefix(source, "local:"):
+		return readLocalManifest(strings.TrimPrefix(source, "local:"), manifest)
+	case strings.HasPrefix(source, "http://") || strings.HasPrefix(source, "https://"):
+		return f.readURL(ctx, source)
+	default:
+		return readLocalManifest(source, manifest)
+	}
+}
+
+func (f SourceFetcher) readURL(ctx context.Context, url string) ([]byte, error) {
+	client := f.HTTPClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", "galaxio-cli")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return nil, fmt.Errorf("GET %s returned %s", url, resp.Status)
+	}
+
+	return io.ReadAll(resp.Body)
+}
+
+func readLocalManifest(root string, manifest string) ([]byte, error) {
+	if root == "" {
+		return nil, errors.New("local source path is required")
+	}
+
+	return os.ReadFile(filepath.Join(root, manifest))
+}
+
+func githubRawURL(repo string, manifest string) string {
+	parts := strings.Split(strings.Trim(repo, "/"), "/")
+	if len(parts) < 2 {
+		return "https://raw.githubusercontent.com/" + strings.Trim(repo, "/") + "/main/" + manifest
+	}
+
+	path := ""
+	if len(parts) > 2 {
+		path = strings.Join(parts[2:], "/") + "/"
+	}
+
+	return "https://raw.githubusercontent.com/" + parts[0] + "/" + parts[1] + "/main/" + path + manifest
+}
+
+func joinSource(source string, child string) string {
+	child = strings.Trim(child, "/")
+	switch {
+	case strings.HasPrefix(source, "github:"):
+		return strings.TrimRight(source, "/") + "/" + child
+	case strings.HasPrefix(source, "local:"):
+		return "local:" + filepath.Join(strings.TrimPrefix(source, "local:"), child)
+	case strings.HasPrefix(source, "http://") || strings.HasPrefix(source, "https://"):
+		return strings.TrimRight(source, "/") + "/" + child + "/" + templateFileName
+	default:
+		return filepath.Join(source, child)
+	}
+}

--- a/internal/templatecatalog/catalog_test.go
+++ b/internal/templatecatalog/catalog_test.go
@@ -1,0 +1,230 @@
+package templatecatalog
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadRegistryFromLocalSource(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, registryFileName, `apiVersion: galaxio.io/v1
+kind: TemplateRegistry
+packs:
+  - name: gatling
+    source: local:/tmp/templates-gatling
+    description: Gatling templates
+`)
+
+	registry, err := SourceFetcher{}.LoadRegistry(context.Background(), root)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(registry.Packs) != 1 {
+		t.Fatalf("expected one pack, got %d", len(registry.Packs))
+	}
+	if registry.Packs[0].Name != "gatling" {
+		t.Fatalf("expected gatling pack, got %q", registry.Packs[0].Name)
+	}
+}
+
+func TestListPacksFromRegistry(t *testing.T) {
+	packRoot := t.TempDir()
+	writeGatlingPack(t, packRoot)
+
+	registryRoot := t.TempDir()
+	writeFile(t, registryRoot, registryFileName, fmt.Sprintf(`apiVersion: galaxio.io/v1
+kind: TemplateRegistry
+packs:
+  - name: gatling
+    source: local:%s
+`, packRoot))
+
+	packs, err := SourceFetcher{}.ListPacks(context.Background(), registryRoot)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(packs) != 1 {
+		t.Fatalf("expected one pack, got %d", len(packs))
+	}
+	if packs[0].Name != "gatling/scala-sbt" {
+		t.Fatalf("expected gatling/scala-sbt, got %q", packs[0].Name)
+	}
+	if !packs[0].Placeholder {
+		t.Fatal("expected placeholder template")
+	}
+}
+
+func TestValidateSourceAcceptsPackWithoutTemplates(t *testing.T) {
+	root := t.TempDir()
+	writeGatlingPack(t, root)
+
+	err := SourceFetcher{}.ValidateSource(context.Background(), root)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestValidateSourceFailsForMissingTemplateManifest(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, packFileName, `apiVersion: galaxio.io/v1
+kind: TemplatePack
+name: gatling
+version: 0.1.0
+templates:
+  - name: fake
+    path: fake
+`)
+
+	err := SourceFetcher{}.ValidateSource(context.Background(), root)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestLoadRegistryFromGitHubSource(t *testing.T) {
+	var gotPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(`apiVersion: galaxio.io/v1
+kind: TemplateRegistry
+packs:
+  - name: gatling
+    source: github:galax-io/templates-gatling
+`))
+	}))
+	defer server.Close()
+
+	fetcher := SourceFetcher{HTTPClient: rewriteClient(t, server.URL)}
+	_, err := fetcher.LoadRegistry(context.Background(), "github:galax-io/galaxio-template-registry")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if gotPath != "/galax-io/galaxio-template-registry/main/galaxio-registry.yaml" {
+		t.Fatalf("unexpected raw path %q", gotPath)
+	}
+}
+
+func TestValidateSourceReadsGitHubTemplateSubpath(t *testing.T) {
+	var paths []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		switch r.URL.Path {
+		case "/galax-io/templates-gatling/main/galaxio-pack.yaml":
+			_, _ = w.Write([]byte(`apiVersion: galaxio.io/v1
+kind: TemplatePack
+name: gatling
+version: 0.1.0
+templates:
+  - name: fake
+    path: fake
+`))
+		case "/galax-io/templates-gatling/main/fake/galaxio-template.yaml":
+			_, _ = w.Write([]byte(`apiVersion: galaxio.io/v1
+kind: Template
+name: fake
+engine: go-template
+inputs:
+  Name:
+    type: string
+files:
+  - from: files
+    to: .
+`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	fetcher := SourceFetcher{HTTPClient: rewriteClient(t, server.URL)}
+	err := fetcher.ValidateSource(context.Background(), "github:galax-io/templates-gatling")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	want := []string{
+		"/galax-io/templates-gatling/main/galaxio-pack.yaml",
+		"/galax-io/templates-gatling/main/fake/galaxio-template.yaml",
+	}
+	if fmt.Sprint(paths) != fmt.Sprint(want) {
+		t.Fatalf("expected paths %v, got %v", want, paths)
+	}
+}
+
+func TestValidateRegistryRejectsMissingPacks(t *testing.T) {
+	err := ValidateRegistry(Registry{
+		APIVersion: "galaxio.io/v1",
+		Kind:       "TemplateRegistry",
+	})
+
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestValidatePackRejectsParentPath(t *testing.T) {
+	err := ValidatePack(Pack{
+		APIVersion: "galaxio.io/v1",
+		Kind:       "TemplatePack",
+		Name:       "gatling",
+		Version:    "0.1.0",
+		Templates: []PackTemplate{
+			{Name: "fake", Path: "../fake"},
+		},
+	})
+
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func writeGatlingPack(t *testing.T, root string) {
+	t.Helper()
+
+	writeFile(t, root, packFileName, `apiVersion: galaxio.io/v1
+kind: TemplatePack
+name: gatling
+version: 0.1.0
+templates:
+  - name: scala-sbt
+    description: Gatling Scala project with sbt
+`)
+}
+
+func writeFile(t *testing.T, root string, name string, content string) {
+	t.Helper()
+
+	path := filepath.Join(root, name)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("create dir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+}
+
+func rewriteClient(t *testing.T, baseURL string) *http.Client {
+	t.Helper()
+
+	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		rewritten, err := http.NewRequestWithContext(req.Context(), req.Method, baseURL+req.URL.Path, nil)
+		if err != nil {
+			return nil, err
+		}
+		rewritten.Header = req.Header.Clone()
+		return http.DefaultTransport.RoundTrip(rewritten)
+	})
+
+	return &http.Client{Transport: transport}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}

--- a/schemas/galaxio-registry.schema.json
+++ b/schemas/galaxio-registry.schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://galaxio.io/schemas/galaxio-registry.schema.json",
+  "title": "Galaxio Template Registry",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["apiVersion", "kind", "packs"],
+  "properties": {
+    "apiVersion": {
+      "const": "galaxio.io/v1"
+    },
+    "kind": {
+      "const": "TemplateRegistry"
+    },
+    "packs": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "source"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "pattern": "^[a-z][a-z0-9-]*$"
+          },
+          "source": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Template pack source, such as github:galax-io/templates-gatling."
+          },
+          "description": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add the default template registry contract and example.
- Add a template catalog loader for local, `local:`, `github:`, and HTTP sources.
- Add `galaxio template list` for registry-backed placeholder discovery.
- Add `galaxio template init <template>` as a no-op placeholder that prints `coming soon`.
- Add `galaxio template validate <source>` for validating template pack manifests.
- Add `galaxio doctor` for checking registry and pack resolution.

## Notes

- Real template rendering is intentionally not included yet.
- `gatling/scala-sbt` is currently a placeholder and `init` does not write files.
- Default remote listing depends on registry and templates-gatling PRs being merged first.

## Validation

- `go test ./...`
- `go vet ./...`
- `go test -race -coverprofile=coverage.out ./...`
- Local coverage threshold check: `coverage 70.1% meets required 30.0%`
- `go build -trimpath -o bin/galaxio ./cmd/galaxio`
- `./bin/galaxio template list --registry local:<temp-registry-pointing-to-local-templates-gatling>`
- `./bin/galaxio template init gatling/scala-sbt`
- `./bin/galaxio template validate local:/Users/i.akhaltsev/IdeaProjects/personal/templates-gatling`
- `./bin/galaxio doctor --registry local:<temp-registry-pointing-to-local-templates-gatling>`
