### PR TITLE
test: cover template commands and errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Check coverage threshold
         env:
-          COVERAGE_THRESHOLD: "30.0"
+          COVERAGE_THRESHOLD: "65.0"
         run: |
           coverage=$(go tool cover -func=coverage.out | awk '/^total:/ { gsub("%", "", $3); print $3 }')
           awk -v coverage="$coverage" -v threshold="$COVERAGE_THRESHOLD" 'BEGIN {

--- a/cmd/galaxio/doctor.go
+++ b/cmd/galaxio/doctor.go
@@ -27,22 +27,17 @@ func newDoctorCommand() *cobra.Command {
 			}
 
 			fetcher := templatecatalog.SourceFetcher{}
-			templates, err := fetcher.ListPacks(cmd.Context(), registry)
+			templates, err := fetcher.ListTemplates(cmd.Context(), registry)
 			if err != nil {
 				return RuntimeError{Err: err}
 			}
 
 			if output == outputJSON {
-				payload, err := encodeJSON(map[string]interface{}{
-					"registry":        registry,
-					"status":          "ok",
-					"templateEntries": len(templates),
-				})
-				if err != nil {
-					return RuntimeError{Err: err}
-				}
-				_, err = cmd.OutOrStdout().Write(payload)
-				if err != nil {
+				if err := writeJSON(cmd.OutOrStdout(), doctorOutput{
+					Registry:        registry,
+					Status:          "ok",
+					TemplateEntries: len(templates),
+				}); err != nil {
 					return RuntimeError{Err: err}
 				}
 				return nil
@@ -65,4 +60,10 @@ func newDoctorCommand() *cobra.Command {
 	cmd.Flags().StringVarP(&output, "output", "o", outputText, "output format: text or json")
 
 	return cmd
+}
+
+type doctorOutput struct {
+	Registry        string `json:"registry"`
+	Status          string `json:"status"`
+	TemplateEntries int    `json:"templateEntries"`
 }

--- a/cmd/galaxio/doctor.go
+++ b/cmd/galaxio/doctor.go
@@ -9,6 +9,7 @@ import (
 
 func newDoctorCommand() *cobra.Command {
 	var registry string
+	var output string
 
 	cmd := &cobra.Command{
 		Use:   "doctor",
@@ -21,10 +22,30 @@ func newDoctorCommand() *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateOutputFormat(output); err != nil {
+				return err
+			}
+
 			fetcher := templatecatalog.SourceFetcher{}
 			templates, err := fetcher.ListPacks(cmd.Context(), registry)
 			if err != nil {
 				return RuntimeError{Err: err}
+			}
+
+			if output == outputJSON {
+				payload, err := encodeJSON(map[string]interface{}{
+					"registry":        registry,
+					"status":          "ok",
+					"templateEntries": len(templates),
+				})
+				if err != nil {
+					return RuntimeError{Err: err}
+				}
+				_, err = cmd.OutOrStdout().Write(payload)
+				if err != nil {
+					return RuntimeError{Err: err}
+				}
+				return nil
 			}
 
 			_, err = fmt.Fprintf(cmd.OutOrStdout(), "OK template registry: %s\n", registry)
@@ -41,6 +62,7 @@ func newDoctorCommand() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&registry, "registry", templatecatalog.DefaultRegistrySource, "template registry source")
+	cmd.Flags().StringVarP(&output, "output", "o", outputText, "output format: text or json")
 
 	return cmd
 }

--- a/cmd/galaxio/output.go
+++ b/cmd/galaxio/output.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 )
 
 const (
@@ -19,7 +20,16 @@ func validateOutputFormat(format string) error {
 	}
 }
 
-func encodeJSON(value interface{}) ([]byte, error) {
+func writeJSON(writer io.Writer, value any) error {
+	payload, err := encodeJSON(value)
+	if err != nil {
+		return err
+	}
+	_, err = writer.Write(payload)
+	return err
+}
+
+func encodeJSON(value any) ([]byte, error) {
 	payload, err := json.Marshal(value)
 	if err != nil {
 		return nil, err

--- a/cmd/galaxio/output.go
+++ b/cmd/galaxio/output.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+const (
+	outputText = "text"
+	outputJSON = "json"
+)
+
+func validateOutputFormat(format string) error {
+	switch format {
+	case outputText, outputJSON:
+		return nil
+	default:
+		return UsageError{Err: fmt.Errorf("unsupported output format %q", format)}
+	}
+}
+
+func encodeJSON(value interface{}) ([]byte, error) {
+	payload, err := json.Marshal(value)
+	if err != nil {
+		return nil, err
+	}
+	return append(payload, '\n'), nil
+}

--- a/cmd/galaxio/root_test.go
+++ b/cmd/galaxio/root_test.go
@@ -68,7 +68,9 @@ func TestTemplateCommandPrintsHelp(t *testing.T) {
 }
 
 func TestTemplateInitPrintsComingSoon(t *testing.T) {
-	code, stdout, stderr := runCLI("template", "init", "gatling/scala-sbt")
+	registryRoot, _ := writeTemplateCatalogFixture(t)
+
+	code, stdout, stderr := runCLI("template", "init", "gatling/scala-sbt", "--registry", "local:"+registryRoot)
 
 	if code != exitOK {
 		t.Fatalf("expected exit code %d, got %d", exitOK, code)
@@ -76,7 +78,7 @@ func TestTemplateInitPrintsComingSoon(t *testing.T) {
 	if stderr != "" {
 		t.Fatalf("expected empty stderr, got %q", stderr)
 	}
-	if want := "Template gatling/scala-sbt is coming soon"; !strings.Contains(stdout, want) {
+	if want := "Template gatling/scala-sbt 0.1.0 is coming soon"; !strings.Contains(stdout, want) {
 		t.Fatalf("expected coming soon output %q, got %q", want, stdout)
 	}
 }

--- a/cmd/galaxio/root_test.go
+++ b/cmd/galaxio/root_test.go
@@ -2,11 +2,14 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
 
 	"github.com/galax-io/galaxio-cli/internal/buildinfo"
+	"github.com/galax-io/galaxio-cli/internal/selfupdate"
+	"github.com/spf13/cobra"
 )
 
 func runCLI(args ...string) (int, string, string) {
@@ -134,8 +137,43 @@ func TestVersionCommandPrintsBuildInfo(t *testing.T) {
 	}
 }
 
+func TestVersionCommandPrintsJSONOutput(t *testing.T) {
+	originalVersion := buildinfo.Version
+	buildinfo.Version = "v1.2.3"
+	t.Cleanup(func() {
+		buildinfo.Version = originalVersion
+	})
+
+	code, stdout, stderr := runCLI("version", "--output", "json")
+
+	if code != exitOK {
+		t.Fatalf("expected exit code %d, got %d", exitOK, code)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var result struct {
+		Version string `json:"version"`
+		Commit  string `json:"commit"`
+		Date    string `json:"date"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("decode json output: %v; output %q", err, stdout)
+	}
+	if result.Version != "1.2.3" {
+		t.Fatalf("expected clean version 1.2.3 in json output, got %#v", result)
+	}
+	if result.Commit == "" {
+		t.Fatalf("expected commit in json output, got %#v", result)
+	}
+	if result.Date == "" {
+		t.Fatalf("expected build date in json output, got %#v", result)
+	}
+}
+
 func TestVersionCommandTrimsTagPrefix(t *testing.T) {
-	originalVersion := versionInfo().Version
+	originalVersion := buildinfo.Version
 	buildinfo.Version = "v1.2.3"
 	t.Cleanup(func() {
 		buildinfo.Version = originalVersion
@@ -165,6 +203,63 @@ func TestVersionFlagPrintsVersion(t *testing.T) {
 	}
 	if want := "galaxio version dev"; !strings.Contains(stdout, want) {
 		t.Fatalf("expected version flag output to contain %q, got %q", want, stdout)
+	}
+}
+
+func TestUpdateResultPrintsJSONOutput(t *testing.T) {
+	var stdout bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&stdout)
+
+	err := printUpdateResult(cmd, selfupdate.Result{
+		CurrentVersion: "0.1.0",
+		TargetVersion:  "0.2.0",
+		DryRun:         true,
+		AssetName:      "galaxio_0.2.0_darwin_arm64.tar.gz",
+	}, outputJSON)
+
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	var result struct {
+		CurrentVersion string `json:"currentVersion"`
+		TargetVersion  string `json:"targetVersion"`
+		Updated        bool   `json:"updated"`
+		DryRun         bool   `json:"dryRun"`
+		AssetName      string `json:"assetName"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("decode json output: %v; output %q", err, stdout.String())
+	}
+	if result.CurrentVersion != "0.1.0" {
+		t.Fatalf("expected current version 0.1.0, got %q", result.CurrentVersion)
+	}
+	if result.TargetVersion != "0.2.0" {
+		t.Fatalf("expected target version 0.2.0, got %q", result.TargetVersion)
+	}
+	if !result.DryRun {
+		t.Fatalf("expected dry run result, got %#v", result)
+	}
+	if result.Updated {
+		t.Fatalf("expected update not installed during dry run, got %#v", result)
+	}
+	if result.AssetName != "galaxio_0.2.0_darwin_arm64.tar.gz" {
+		t.Fatalf("expected asset name, got %q", result.AssetName)
+	}
+}
+
+func TestUpdateRejectsUnsupportedOutputBeforeRunning(t *testing.T) {
+	code, stdout, stderr := runCLI("update", "--output", "xml")
+
+	if code != exitUsage {
+		t.Fatalf("expected exit code %d, got %d", exitUsage, code)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, `unsupported output format "xml"`) {
+		t.Fatalf("expected unsupported output error, got %q", stderr)
 	}
 }
 

--- a/cmd/galaxio/template.go
+++ b/cmd/galaxio/template.go
@@ -32,6 +32,7 @@ func newTemplateCommand() *cobra.Command {
 
 func newTemplateListCommand() *cobra.Command {
 	var registry string
+	var output string
 
 	cmd := &cobra.Command{
 		Use:   "list",
@@ -44,9 +45,25 @@ func newTemplateListCommand() *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateOutputFormat(output); err != nil {
+				return err
+			}
+
 			packs, err := (templatecatalog.SourceFetcher{}).ListPacks(cmd.Context(), registry)
 			if err != nil {
 				return RuntimeError{Err: err}
+			}
+
+			if output == outputJSON {
+				payload, err := encodeJSON(packs)
+				if err != nil {
+					return RuntimeError{Err: err}
+				}
+				_, err = cmd.OutOrStdout().Write(payload)
+				if err != nil {
+					return RuntimeError{Err: err}
+				}
+				return nil
 			}
 
 			for _, pack := range packs {
@@ -69,11 +86,14 @@ func newTemplateListCommand() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&registry, "registry", templatecatalog.DefaultRegistrySource, "template registry source")
+	cmd.Flags().StringVarP(&output, "output", "o", outputText, "output format: text or json")
 
 	return cmd
 }
 
 func newTemplateInitCommand() *cobra.Command {
+	var output string
+
 	cmd := &cobra.Command{
 		Use:   "init <template>",
 		Short: "Initialize a project from a template.",
@@ -85,6 +105,24 @@ func newTemplateInitCommand() *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateOutputFormat(output); err != nil {
+				return err
+			}
+			if output == outputJSON {
+				payload, err := encodeJSON(map[string]string{
+					"template": args[0],
+					"status":   "coming_soon",
+				})
+				if err != nil {
+					return RuntimeError{Err: err}
+				}
+				_, err = cmd.OutOrStdout().Write(payload)
+				if err != nil {
+					return RuntimeError{Err: err}
+				}
+				return nil
+			}
+
 			_, err := fmt.Fprintf(cmd.OutOrStdout(), "Template %s is coming soon\n", args[0])
 			if err != nil {
 				return RuntimeError{Err: err}
@@ -93,10 +131,14 @@ func newTemplateInitCommand() *cobra.Command {
 		},
 	}
 
+	cmd.Flags().StringVarP(&output, "output", "o", outputText, "output format: text or json")
+
 	return cmd
 }
 
 func newTemplateValidateCommand() *cobra.Command {
+	var output string
+
 	cmd := &cobra.Command{
 		Use:   "validate <source>",
 		Short: "Validate a template pack.",
@@ -108,9 +150,28 @@ func newTemplateValidateCommand() *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateOutputFormat(output); err != nil {
+				return err
+			}
+
 			source := args[0]
 			if err := (templatecatalog.SourceFetcher{}).ValidateSource(cmd.Context(), source); err != nil {
 				return RuntimeError{Err: err}
+			}
+
+			if output == outputJSON {
+				payload, err := encodeJSON(map[string]string{
+					"source": source,
+					"status": "valid",
+				})
+				if err != nil {
+					return RuntimeError{Err: err}
+				}
+				_, err = cmd.OutOrStdout().Write(payload)
+				if err != nil {
+					return RuntimeError{Err: err}
+				}
+				return nil
 			}
 
 			_, err := fmt.Fprintf(cmd.OutOrStdout(), "Template pack %s is valid\n", source)
@@ -121,6 +182,8 @@ func newTemplateValidateCommand() *cobra.Command {
 			return nil
 		},
 	}
+
+	cmd.Flags().StringVarP(&output, "output", "o", outputText, "output format: text or json")
 
 	return cmd
 }

--- a/cmd/galaxio/template.go
+++ b/cmd/galaxio/template.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"errors"
 	"fmt"
+	"io"
 
 	"github.com/galax-io/galaxio-cli/internal/templatecatalog"
 	"github.com/spf13/cobra"
@@ -49,32 +51,20 @@ func newTemplateListCommand() *cobra.Command {
 				return err
 			}
 
-			packs, err := (templatecatalog.SourceFetcher{}).ListPacks(cmd.Context(), registry)
+			templates, err := (templatecatalog.SourceFetcher{}).ListTemplates(cmd.Context(), registry)
 			if err != nil {
 				return RuntimeError{Err: err}
 			}
 
 			if output == outputJSON {
-				payload, err := encodeJSON(packs)
-				if err != nil {
-					return RuntimeError{Err: err}
-				}
-				_, err = cmd.OutOrStdout().Write(payload)
-				if err != nil {
+				if err := writeJSON(cmd.OutOrStdout(), templates); err != nil {
 					return RuntimeError{Err: err}
 				}
 				return nil
 			}
 
-			for _, pack := range packs {
-				if pack.Description == "" {
-					_, err = fmt.Fprintf(cmd.OutOrStdout(), "%s\t%s\t%s\n", pack.Name, pack.Version, pack.Source)
-				} else {
-					_, err = fmt.Fprintf(cmd.OutOrStdout(), "%s\t%s\t%s\t%s\n", pack.Name, pack.Version, pack.Source, pack.Description)
-				}
-				if err != nil {
-					return RuntimeError{Err: err}
-				}
+			if err := writeTemplateList(cmd.OutOrStdout(), templates); err != nil {
+				return RuntimeError{Err: err}
 			}
 
 			return nil
@@ -88,12 +78,13 @@ func newTemplateListCommand() *cobra.Command {
 }
 
 func newTemplateInitCommand() *cobra.Command {
+	var registry string
 	var output string
 
 	cmd := &cobra.Command{
 		Use:   "init <template>",
 		Short: "Initialize a project from a template.",
-		Long:  "Initialize a project from a template. Rendering support is not available yet.",
+		Long:  "Initialize a project from a template resolved from a Galaxio template registry.",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if err := cobra.ExactArgs(1)(cmd, args); err != nil {
 				return UsageError{Err: err}
@@ -104,22 +95,30 @@ func newTemplateInitCommand() *cobra.Command {
 			if err := validateOutputFormat(output); err != nil {
 				return err
 			}
-			if output == outputJSON {
-				payload, err := encodeJSON(map[string]string{
-					"template": args[0],
-					"status":   "coming_soon",
-				})
-				if err != nil {
-					return RuntimeError{Err: err}
+			template, err := (templatecatalog.SourceFetcher{}).FindTemplate(cmd.Context(), registry, args[0])
+			if err != nil {
+				if errors.Is(err, templatecatalog.ErrTemplateNotFound) {
+					return UsageError{Err: err}
 				}
-				_, err = cmd.OutOrStdout().Write(payload)
-				if err != nil {
+				return RuntimeError{Err: err}
+			}
+			if !template.Placeholder {
+				return RuntimeError{Err: fmt.Errorf("template %q is available, but rendering is not implemented yet", template.Name)}
+			}
+
+			if output == outputJSON {
+				if err := writeJSON(cmd.OutOrStdout(), templateInitOutput{
+					Template: template.Name,
+					Version:  template.Version,
+					Source:   template.Source,
+					Status:   templateInitStatusComingSoon,
+				}); err != nil {
 					return RuntimeError{Err: err}
 				}
 				return nil
 			}
 
-			_, err := fmt.Fprintf(cmd.OutOrStdout(), "Template %s is coming soon\n", args[0])
+			_, err = fmt.Fprintf(cmd.OutOrStdout(), "Template %s %s is coming soon\n", template.Name, template.Version)
 			if err != nil {
 				return RuntimeError{Err: err}
 			}
@@ -127,6 +126,7 @@ func newTemplateInitCommand() *cobra.Command {
 		},
 	}
 
+	cmd.Flags().StringVar(&registry, "registry", templatecatalog.DefaultRegistrySource, "template registry source")
 	cmd.Flags().StringVarP(&output, "output", "o", outputText, "output format: text or json")
 
 	return cmd
@@ -156,15 +156,10 @@ func newTemplateValidateCommand() *cobra.Command {
 			}
 
 			if output == outputJSON {
-				payload, err := encodeJSON(map[string]string{
-					"source": source,
-					"status": "valid",
-				})
-				if err != nil {
-					return RuntimeError{Err: err}
-				}
-				_, err = cmd.OutOrStdout().Write(payload)
-				if err != nil {
+				if err := writeJSON(cmd.OutOrStdout(), templateValidateOutput{
+					Source: source,
+					Status: "valid",
+				}); err != nil {
 					return RuntimeError{Err: err}
 				}
 				return nil
@@ -182,4 +177,34 @@ func newTemplateValidateCommand() *cobra.Command {
 	cmd.Flags().StringVarP(&output, "output", "o", outputText, "output format: text or json")
 
 	return cmd
+}
+
+const templateInitStatusComingSoon = "coming_soon"
+
+type templateInitOutput struct {
+	Template string `json:"template"`
+	Version  string `json:"version"`
+	Source   string `json:"source"`
+	Status   string `json:"status"`
+}
+
+type templateValidateOutput struct {
+	Source string `json:"source"`
+	Status string `json:"status"`
+}
+
+func writeTemplateList(writer io.Writer, templates []templatecatalog.TemplateRef) error {
+	for _, template := range templates {
+		if template.Description == "" {
+			if _, err := fmt.Fprintf(writer, "%s\t%s\t%s\n", template.Name, template.Version, template.Source); err != nil {
+				return err
+			}
+			continue
+		}
+		if _, err := fmt.Fprintf(writer, "%s\t%s\t%s\t%s\n", template.Name, template.Version, template.Source, template.Description); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/cmd/galaxio/template.go
+++ b/cmd/galaxio/template.go
@@ -67,14 +67,10 @@ func newTemplateListCommand() *cobra.Command {
 			}
 
 			for _, pack := range packs {
-				state := "available"
-				if pack.Placeholder {
-					state = "coming soon"
-				}
 				if pack.Description == "" {
-					_, err = fmt.Fprintf(cmd.OutOrStdout(), "%s\t%s\t%s\n", pack.Name, state, pack.Source)
+					_, err = fmt.Fprintf(cmd.OutOrStdout(), "%s\t%s\t%s\n", pack.Name, pack.Version, pack.Source)
 				} else {
-					_, err = fmt.Fprintf(cmd.OutOrStdout(), "%s\t%s\t%s\t%s\n", pack.Name, state, pack.Source, pack.Description)
+					_, err = fmt.Fprintf(cmd.OutOrStdout(), "%s\t%s\t%s\t%s\n", pack.Name, pack.Version, pack.Source, pack.Description)
 				}
 				if err != nil {
 					return RuntimeError{Err: err}

--- a/cmd/galaxio/template_command_test.go
+++ b/cmd/galaxio/template_command_test.go
@@ -19,10 +19,13 @@ func TestTemplateListWithLocalRegistry(t *testing.T) {
 	if stderr != "" {
 		t.Fatalf("expected empty stderr, got %q", stderr)
 	}
-	for _, want := range []string{"gatling/scala-sbt", "coming soon", "local:" + packRoot, "Gatling Scala project with sbt"} {
+	for _, want := range []string{"gatling/scala-sbt", "0.1.0", "local:" + packRoot, "Gatling Scala project with sbt"} {
 		if !strings.Contains(stdout, want) {
 			t.Fatalf("expected output to contain %q, got %q", want, stdout)
 		}
+	}
+	if strings.Contains(stdout, "coming soon") {
+		t.Fatalf("expected template list to omit placeholder status, got %q", stdout)
 	}
 }
 
@@ -41,6 +44,7 @@ func TestTemplateListWithJSONOutput(t *testing.T) {
 	var refs []struct {
 		Name        string `json:"name"`
 		Pack        string `json:"pack"`
+		Version     string `json:"version"`
 		Source      string `json:"source"`
 		Description string `json:"description"`
 		Templates   int    `json:"templates"`
@@ -58,6 +62,9 @@ func TestTemplateListWithJSONOutput(t *testing.T) {
 	}
 	if ref.Pack != "gatling" {
 		t.Fatalf("expected pack gatling, got %q", ref.Pack)
+	}
+	if ref.Version != "0.1.0" {
+		t.Fatalf("expected version 0.1.0, got %q", ref.Version)
 	}
 	if ref.Source != "local:"+packRoot {
 		t.Fatalf("expected source local:%s, got %q", packRoot, ref.Source)

--- a/cmd/galaxio/template_command_test.go
+++ b/cmd/galaxio/template_command_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -25,6 +26,53 @@ func TestTemplateListWithLocalRegistry(t *testing.T) {
 	}
 }
 
+func TestTemplateListWithJSONOutput(t *testing.T) {
+	registryRoot, packRoot := writeTemplateCatalogFixture(t)
+
+	code, stdout, stderr := runCLI("template", "list", "--registry", "local:"+registryRoot, "--output", "json")
+
+	if code != exitOK {
+		t.Fatalf("expected exit code %d, got %d, stderr %q", exitOK, code, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var refs []struct {
+		Name        string `json:"name"`
+		Pack        string `json:"pack"`
+		Source      string `json:"source"`
+		Description string `json:"description"`
+		Templates   int    `json:"templates"`
+		Placeholder bool   `json:"placeholder"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &refs); err != nil {
+		t.Fatalf("decode json output: %v; output %q", err, stdout)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("expected one template ref, got %#v", refs)
+	}
+	ref := refs[0]
+	if ref.Name != "gatling/scala-sbt" {
+		t.Fatalf("expected template name gatling/scala-sbt, got %q", ref.Name)
+	}
+	if ref.Pack != "gatling" {
+		t.Fatalf("expected pack gatling, got %q", ref.Pack)
+	}
+	if ref.Source != "local:"+packRoot {
+		t.Fatalf("expected source local:%s, got %q", packRoot, ref.Source)
+	}
+	if ref.Description != "Gatling Scala project with sbt" {
+		t.Fatalf("expected template description, got %q", ref.Description)
+	}
+	if ref.Templates != 1 {
+		t.Fatalf("expected one template in pack, got %d", ref.Templates)
+	}
+	if !ref.Placeholder {
+		t.Fatalf("expected placeholder template, got %#v", ref)
+	}
+}
+
 func TestTemplateListReportsMissingRegistry(t *testing.T) {
 	missing := filepath.Join(t.TempDir(), "missing")
 
@@ -43,6 +91,22 @@ func TestTemplateListReportsMissingRegistry(t *testing.T) {
 	}
 }
 
+func TestTemplateListRejectsUnsupportedOutput(t *testing.T) {
+	registryRoot, _ := writeTemplateCatalogFixture(t)
+
+	code, stdout, stderr := runCLI("template", "list", "--registry", "local:"+registryRoot, "--output", "xml")
+
+	if code != exitUsage {
+		t.Fatalf("expected exit code %d, got %d", exitUsage, code)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, `unsupported output format "xml"`) {
+		t.Fatalf("expected unsupported output error, got %q", stderr)
+	}
+}
+
 func TestTemplateValidateWithLocalPack(t *testing.T) {
 	_, packRoot := writeTemplateCatalogFixture(t)
 
@@ -56,6 +120,34 @@ func TestTemplateValidateWithLocalPack(t *testing.T) {
 	}
 	if want := "Template pack local:" + packRoot + " is valid"; !strings.Contains(stdout, want) {
 		t.Fatalf("expected output to contain %q, got %q", want, stdout)
+	}
+}
+
+func TestTemplateValidateWithJSONOutput(t *testing.T) {
+	_, packRoot := writeTemplateCatalogFixture(t)
+
+	source := "local:" + packRoot
+	code, stdout, stderr := runCLI("template", "validate", source, "--output", "json")
+
+	if code != exitOK {
+		t.Fatalf("expected exit code %d, got %d, stderr %q", exitOK, code, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var result struct {
+		Source string `json:"source"`
+		Status string `json:"status"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("decode json output: %v; output %q", err, stdout)
+	}
+	if result.Source != source {
+		t.Fatalf("expected source %q, got %q", source, result.Source)
+	}
+	if result.Status != "valid" {
+		t.Fatalf("expected status valid, got %q", result.Status)
 	}
 }
 
@@ -83,6 +175,31 @@ templates: []
 	}
 }
 
+func TestTemplateInitWithJSONOutput(t *testing.T) {
+	code, stdout, stderr := runCLI("template", "init", "gatling/scala-sbt", "--output", "json")
+
+	if code != exitOK {
+		t.Fatalf("expected exit code %d, got %d, stderr %q", exitOK, code, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var result struct {
+		Template string `json:"template"`
+		Status   string `json:"status"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("decode json output: %v; output %q", err, stdout)
+	}
+	if result.Template != "gatling/scala-sbt" {
+		t.Fatalf("expected template gatling/scala-sbt, got %q", result.Template)
+	}
+	if result.Status != "coming_soon" {
+		t.Fatalf("expected status coming_soon, got %q", result.Status)
+	}
+}
+
 func TestDoctorWithLocalRegistry(t *testing.T) {
 	registryRoot, _ := writeTemplateCatalogFixture(t)
 
@@ -98,6 +215,38 @@ func TestDoctorWithLocalRegistry(t *testing.T) {
 		if !strings.Contains(stdout, want) {
 			t.Fatalf("expected output to contain %q, got %q", want, stdout)
 		}
+	}
+}
+
+func TestDoctorWithJSONOutput(t *testing.T) {
+	registryRoot, _ := writeTemplateCatalogFixture(t)
+
+	registry := "local:" + registryRoot
+	code, stdout, stderr := runCLI("doctor", "--registry", registry, "--output", "json")
+
+	if code != exitOK {
+		t.Fatalf("expected exit code %d, got %d, stderr %q", exitOK, code, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var result struct {
+		Registry        string `json:"registry"`
+		Status          string `json:"status"`
+		TemplateEntries int    `json:"templateEntries"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("decode json output: %v; output %q", err, stdout)
+	}
+	if result.Registry != registry {
+		t.Fatalf("expected registry %q, got %q", registry, result.Registry)
+	}
+	if result.Status != "ok" {
+		t.Fatalf("expected status ok, got %q", result.Status)
+	}
+	if result.TemplateEntries != 1 {
+		t.Fatalf("expected one template entry, got %d", result.TemplateEntries)
 	}
 }
 

--- a/cmd/galaxio/template_command_test.go
+++ b/cmd/galaxio/template_command_test.go
@@ -183,7 +183,9 @@ templates: []
 }
 
 func TestTemplateInitWithJSONOutput(t *testing.T) {
-	code, stdout, stderr := runCLI("template", "init", "gatling/scala-sbt", "--output", "json")
+	registryRoot, packRoot := writeTemplateCatalogFixture(t)
+
+	code, stdout, stderr := runCLI("template", "init", "gatling/scala-sbt", "--registry", "local:"+registryRoot, "--output", "json")
 
 	if code != exitOK {
 		t.Fatalf("expected exit code %d, got %d, stderr %q", exitOK, code, stderr)
@@ -194,6 +196,8 @@ func TestTemplateInitWithJSONOutput(t *testing.T) {
 
 	var result struct {
 		Template string `json:"template"`
+		Version  string `json:"version"`
+		Source   string `json:"source"`
 		Status   string `json:"status"`
 	}
 	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
@@ -202,8 +206,32 @@ func TestTemplateInitWithJSONOutput(t *testing.T) {
 	if result.Template != "gatling/scala-sbt" {
 		t.Fatalf("expected template gatling/scala-sbt, got %q", result.Template)
 	}
+	if result.Version != "0.1.0" {
+		t.Fatalf("expected version 0.1.0, got %q", result.Version)
+	}
+	if result.Source != "local:"+packRoot {
+		t.Fatalf("expected source local:%s, got %q", packRoot, result.Source)
+	}
 	if result.Status != "coming_soon" {
 		t.Fatalf("expected status coming_soon, got %q", result.Status)
+	}
+}
+
+func TestTemplateInitReportsUnknownTemplate(t *testing.T) {
+	registryRoot, _ := writeTemplateCatalogFixture(t)
+
+	code, stdout, stderr := runCLI("template", "init", "missing/template", "--registry", "local:"+registryRoot)
+
+	if code != exitUsage {
+		t.Fatalf("expected exit code %d, got %d", exitUsage, code)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	for _, want := range []string{"template not found", "missing/template"} {
+		if !strings.Contains(stderr, want) {
+			t.Fatalf("expected error to contain %q, got %q", want, stderr)
+		}
 	}
 }
 

--- a/cmd/galaxio/template_command_test.go
+++ b/cmd/galaxio/template_command_test.go
@@ -1,0 +1,172 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestTemplateListWithLocalRegistry(t *testing.T) {
+	registryRoot, packRoot := writeTemplateCatalogFixture(t)
+
+	code, stdout, stderr := runCLI("template", "list", "--registry", "local:"+registryRoot)
+
+	if code != exitOK {
+		t.Fatalf("expected exit code %d, got %d, stderr %q", exitOK, code, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	for _, want := range []string{"gatling/scala-sbt", "coming soon", "local:" + packRoot, "Gatling Scala project with sbt"} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("expected output to contain %q, got %q", want, stdout)
+		}
+	}
+}
+
+func TestTemplateListReportsMissingRegistry(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "missing")
+
+	code, stdout, stderr := runCLI("template", "list", "--registry", "local:"+missing)
+
+	if code != exitRuntime {
+		t.Fatalf("expected exit code %d, got %d", exitRuntime, code)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	for _, want := range []string{"read template registry", "galaxio-registry.yaml", "not found"} {
+		if !strings.Contains(stderr, want) {
+			t.Fatalf("expected error to contain %q, got %q", want, stderr)
+		}
+	}
+}
+
+func TestTemplateValidateWithLocalPack(t *testing.T) {
+	_, packRoot := writeTemplateCatalogFixture(t)
+
+	code, stdout, stderr := runCLI("template", "validate", "local:"+packRoot)
+
+	if code != exitOK {
+		t.Fatalf("expected exit code %d, got %d, stderr %q", exitOK, code, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if want := "Template pack local:" + packRoot + " is valid"; !strings.Contains(stdout, want) {
+		t.Fatalf("expected output to contain %q, got %q", want, stdout)
+	}
+}
+
+func TestTemplateValidateReportsInvalidPack(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, root, "galaxio-pack.yaml", `apiVersion: galaxio.io/v1
+kind: WrongKind
+name: gatling
+version: 0.1.0
+templates: []
+`)
+
+	code, stdout, stderr := runCLI("template", "validate", "local:"+root)
+
+	if code != exitRuntime {
+		t.Fatalf("expected exit code %d, got %d", exitRuntime, code)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	for _, want := range []string{"validate template pack", "pack kind must be TemplatePack"} {
+		if !strings.Contains(stderr, want) {
+			t.Fatalf("expected error to contain %q, got %q", want, stderr)
+		}
+	}
+}
+
+func TestDoctorWithLocalRegistry(t *testing.T) {
+	registryRoot, _ := writeTemplateCatalogFixture(t)
+
+	code, stdout, stderr := runCLI("doctor", "--registry", "local:"+registryRoot)
+
+	if code != exitOK {
+		t.Fatalf("expected exit code %d, got %d, stderr %q", exitOK, code, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	for _, want := range []string{"OK template registry: local:" + registryRoot, "OK template entries: 1"} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("expected output to contain %q, got %q", want, stdout)
+		}
+	}
+}
+
+func TestDoctorReportsRegistryErrors(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "missing")
+
+	code, stdout, stderr := runCLI("doctor", "--registry", "local:"+missing)
+
+	if code != exitRuntime {
+		t.Fatalf("expected exit code %d, got %d", exitRuntime, code)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	for _, want := range []string{"read template registry", "not found"} {
+		if !strings.Contains(stderr, want) {
+			t.Fatalf("expected error to contain %q, got %q", want, stderr)
+		}
+	}
+}
+
+func TestTemplateInitRequiresTemplateName(t *testing.T) {
+	code, stdout, stderr := runCLI("template", "init")
+
+	if code != exitUsage {
+		t.Fatalf("expected exit code %d, got %d", exitUsage, code)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "accepts 1 arg") {
+		t.Fatalf("expected argument validation error, got %q", stderr)
+	}
+}
+
+func writeTemplateCatalogFixture(t *testing.T) (string, string) {
+	t.Helper()
+
+	packRoot := t.TempDir()
+	writeTestFile(t, packRoot, "galaxio-pack.yaml", `apiVersion: galaxio.io/v1
+kind: TemplatePack
+name: gatling
+version: 0.1.0
+description: Gatling performance testing templates
+templates:
+  - name: scala-sbt
+    description: Gatling Scala project with sbt
+`)
+
+	registryRoot := t.TempDir()
+	writeTestFile(t, registryRoot, "galaxio-registry.yaml", `apiVersion: galaxio.io/v1
+kind: TemplateRegistry
+packs:
+  - name: gatling
+    source: local:`+packRoot+`
+    description: Gatling performance testing templates
+`)
+
+	return registryRoot, packRoot
+}
+
+func writeTestFile(t *testing.T, root string, name string, content string) {
+	t.Helper()
+
+	path := filepath.Join(root, name)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("create dir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+}

--- a/cmd/galaxio/update.go
+++ b/cmd/galaxio/update.go
@@ -69,12 +69,7 @@ func printUpdateResult(cmd *cobra.Command, result selfupdate.Result, output stri
 		return err
 	}
 	if output == outputJSON {
-		payload, err := encodeJSON(result)
-		if err != nil {
-			return err
-		}
-		_, err = cmd.OutOrStdout().Write(payload)
-		return err
+		return writeJSON(cmd.OutOrStdout(), result)
 	}
 
 	switch {

--- a/cmd/galaxio/update.go
+++ b/cmd/galaxio/update.go
@@ -12,6 +12,7 @@ type updateOptions struct {
 	repo    string
 	version string
 	dryRun  bool
+	output  string
 }
 
 func newUpdateCommand() *cobra.Command {
@@ -28,6 +29,10 @@ func newUpdateCommand() *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateOutputFormat(opts.output); err != nil {
+				return err
+			}
+
 			executable, err := os.Executable()
 			if err != nil {
 				return RuntimeError{Err: fmt.Errorf("resolve executable path: %w", err)}
@@ -44,7 +49,7 @@ func newUpdateCommand() *cobra.Command {
 				return RuntimeError{Err: err}
 			}
 
-			if err := printUpdateResult(cmd, result); err != nil {
+			if err := printUpdateResult(cmd, result, opts.output); err != nil {
 				return RuntimeError{Err: err}
 			}
 			return nil
@@ -54,11 +59,24 @@ func newUpdateCommand() *cobra.Command {
 	cmd.Flags().StringVar(&opts.repo, "repo", "galax-io/galaxio-cli", "GitHub repository to update from")
 	cmd.Flags().StringVar(&opts.version, "version", "", "target version to install")
 	cmd.Flags().BoolVar(&opts.dryRun, "dry-run", false, "check for an update without installing it")
+	cmd.Flags().StringVarP(&opts.output, "output", "o", outputText, "output format: text or json")
 
 	return cmd
 }
 
-func printUpdateResult(cmd *cobra.Command, result selfupdate.Result) error {
+func printUpdateResult(cmd *cobra.Command, result selfupdate.Result, output string) error {
+	if err := validateOutputFormat(output); err != nil {
+		return err
+	}
+	if output == outputJSON {
+		payload, err := encodeJSON(result)
+		if err != nil {
+			return err
+		}
+		_, err = cmd.OutOrStdout().Write(payload)
+		return err
+	}
+
 	switch {
 	case result.Updated:
 		_, err := fmt.Fprintf(cmd.OutOrStdout(), "Updated galaxio from %s to %s\n", result.CurrentVersion, result.TargetVersion)

--- a/cmd/galaxio/version.go
+++ b/cmd/galaxio/version.go
@@ -27,16 +27,11 @@ func newVersionCommand() *cobra.Command {
 
 			info := versionInfo()
 			if output == outputJSON {
-				payload, err := encodeJSON(versionOutput{
+				if err := writeJSON(cmd.OutOrStdout(), versionOutput{
 					Version: info.CleanVersion(),
 					Commit:  info.Commit,
 					Date:    info.Date,
-				})
-				if err != nil {
-					return RuntimeError{Err: err}
-				}
-				_, err = cmd.OutOrStdout().Write(payload)
-				if err != nil {
+				}); err != nil {
 					return RuntimeError{Err: err}
 				}
 				return nil

--- a/cmd/galaxio/version.go
+++ b/cmd/galaxio/version.go
@@ -8,7 +8,9 @@ import (
 )
 
 func newVersionCommand() *cobra.Command {
-	return &cobra.Command{
+	var output string
+
+	cmd := &cobra.Command{
 		Use:   "version",
 		Short: "Print version information.",
 		Long:  "Print version, commit, and build date information for the galaxio binary.",
@@ -19,13 +21,44 @@ func newVersionCommand() *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			_, err := fmt.Fprintln(cmd.OutOrStdout(), versionInfo().String())
+			if err := validateOutputFormat(output); err != nil {
+				return err
+			}
+
+			info := versionInfo()
+			if output == outputJSON {
+				payload, err := encodeJSON(versionOutput{
+					Version: info.CleanVersion(),
+					Commit:  info.Commit,
+					Date:    info.Date,
+				})
+				if err != nil {
+					return RuntimeError{Err: err}
+				}
+				_, err = cmd.OutOrStdout().Write(payload)
+				if err != nil {
+					return RuntimeError{Err: err}
+				}
+				return nil
+			}
+
+			_, err := fmt.Fprintln(cmd.OutOrStdout(), info.String())
 			if err != nil {
 				return RuntimeError{Err: err}
 			}
 			return nil
 		},
 	}
+
+	cmd.Flags().StringVarP(&output, "output", "o", outputText, "output format: text or json")
+
+	return cmd
+}
+
+type versionOutput struct {
+	Version string `json:"version"`
+	Commit  string `json:"commit"`
+	Date    string `json:"date"`
 }
 
 func versionInfo() buildinfo.Info {

--- a/internal/selfupdate/selfupdate.go
+++ b/internal/selfupdate/selfupdate.go
@@ -39,11 +39,11 @@ type Options struct {
 
 // Result describes the outcome of a self-update run.
 type Result struct {
-	CurrentVersion string
-	TargetVersion  string
-	Updated        bool
-	DryRun         bool
-	AssetName      string
+	CurrentVersion string `json:"currentVersion"`
+	TargetVersion  string `json:"targetVersion"`
+	Updated        bool   `json:"updated"`
+	DryRun         bool   `json:"dryRun"`
+	AssetName      string `json:"assetName,omitempty"`
 }
 
 // Updater updates galaxio from GitHub Releases.

--- a/internal/templatecatalog/catalog.go
+++ b/internal/templatecatalog/catalog.go
@@ -75,12 +75,12 @@ type TemplateFile struct {
 
 // TemplateRef is a resolved template available to users.
 type TemplateRef struct {
-	Name        string
-	Pack        string
-	Source      string
-	Description string
-	Templates   int
-	Placeholder bool
+	Name        string `json:"name"`
+	Pack        string `json:"pack"`
+	Source      string `json:"source"`
+	Description string `json:"description,omitempty"`
+	Templates   int    `json:"templates"`
+	Placeholder bool   `json:"placeholder"`
 }
 
 // SourceFetcher loads manifest files from local paths or remote sources.

--- a/internal/templatecatalog/catalog.go
+++ b/internal/templatecatalog/catalog.go
@@ -22,6 +22,10 @@ const (
 	templateFileName      = "galaxio-template.yaml"
 )
 
+// ErrTemplateNotFound is returned when a registry does not contain a requested
+// template reference.
+var ErrTemplateNotFound = errors.New("template not found")
+
 // Registry is the root index of available template packs.
 type Registry struct {
 	APIVersion string         `yaml:"apiVersion"`
@@ -55,16 +59,16 @@ type PackTemplate struct {
 
 // Template describes one renderable template.
 type Template struct {
-	APIVersion  string                 `yaml:"apiVersion"`
-	Kind        string                 `yaml:"kind"`
-	Name        string                 `yaml:"name"`
-	DisplayName string                 `yaml:"displayName"`
-	Description string                 `yaml:"description"`
-	Engine      string                 `yaml:"engine"`
-	Tags        []string               `yaml:"tags"`
-	Inputs      map[string]interface{} `yaml:"inputs"`
-	Computed    map[string]string      `yaml:"computed"`
-	Files       []TemplateFile         `yaml:"files"`
+	APIVersion  string            `yaml:"apiVersion"`
+	Kind        string            `yaml:"kind"`
+	Name        string            `yaml:"name"`
+	DisplayName string            `yaml:"displayName"`
+	Description string            `yaml:"description"`
+	Engine      string            `yaml:"engine"`
+	Tags        []string          `yaml:"tags"`
+	Inputs      map[string]any    `yaml:"inputs"`
+	Computed    map[string]string `yaml:"computed"`
+	Files       []TemplateFile    `yaml:"files"`
 }
 
 // TemplateFile describes one file mapping in a template.
@@ -165,8 +169,8 @@ func (f SourceFetcher) LoadTemplate(ctx context.Context, packSource string, temp
 	return template, nil
 }
 
-// ListPacks reads the registry and validates referenced packs.
-func (f SourceFetcher) ListPacks(ctx context.Context, registrySource string) ([]TemplateRef, error) {
+// ListTemplates reads the registry and resolves templates from referenced packs.
+func (f SourceFetcher) ListTemplates(ctx context.Context, registrySource string) ([]TemplateRef, error) {
 	registry, err := f.LoadRegistry(ctx, registrySource)
 	if err != nil {
 		return nil, err
@@ -192,6 +196,22 @@ func (f SourceFetcher) ListPacks(ctx context.Context, registrySource string) ([]
 	}
 
 	return result, nil
+}
+
+// FindTemplate resolves a template reference from a registry.
+func (f SourceFetcher) FindTemplate(ctx context.Context, registrySource string, name string) (TemplateRef, error) {
+	templates, err := f.ListTemplates(ctx, registrySource)
+	if err != nil {
+		return TemplateRef{}, err
+	}
+
+	for _, template := range templates {
+		if template.Name == name {
+			return template, nil
+		}
+	}
+
+	return TemplateRef{}, fmt.Errorf("%w: %s", ErrTemplateNotFound, name)
 }
 
 // ValidateSource validates a template pack source and its template manifests.

--- a/internal/templatecatalog/catalog.go
+++ b/internal/templatecatalog/catalog.go
@@ -77,6 +77,7 @@ type TemplateFile struct {
 type TemplateRef struct {
 	Name        string `json:"name"`
 	Pack        string `json:"pack"`
+	Version     string `json:"version"`
 	Source      string `json:"source"`
 	Description string `json:"description,omitempty"`
 	Templates   int    `json:"templates"`
@@ -181,6 +182,7 @@ func (f SourceFetcher) ListPacks(ctx context.Context, registrySource string) ([]
 			result = append(result, TemplateRef{
 				Name:        pack.Name + "/" + template.Name,
 				Pack:        pack.Name,
+				Version:     pack.Version,
 				Source:      registryPack.Source,
 				Description: template.Description,
 				Templates:   len(pack.Templates),

--- a/internal/templatecatalog/catalog.go
+++ b/internal/templatecatalog/catalog.go
@@ -88,6 +88,21 @@ type SourceFetcher struct {
 	HTTPClient *http.Client
 }
 
+// SourceError adds user-facing context to source loading failures.
+type SourceError struct {
+	Source string
+	What   string
+	Err    error
+}
+
+func (e SourceError) Error() string {
+	return fmt.Sprintf("%s %q: %v", e.What, e.Source, e.Err)
+}
+
+func (e SourceError) Unwrap() error {
+	return e.Err
+}
+
 // LoadRegistry loads and validates a registry manifest from source.
 func (f SourceFetcher) LoadRegistry(ctx context.Context, source string) (Registry, error) {
 	if source == "" {
@@ -96,16 +111,16 @@ func (f SourceFetcher) LoadRegistry(ctx context.Context, source string) (Registr
 
 	payload, err := f.readManifest(ctx, source, registryFileName)
 	if err != nil {
-		return Registry{}, err
+		return Registry{}, SourceError{Source: sourceOrDefault(source), What: "read template registry", Err: err}
 	}
 
 	var registry Registry
 	if err := yaml.Unmarshal(payload, &registry); err != nil {
-		return Registry{}, fmt.Errorf("decode registry: %w", err)
+		return Registry{}, SourceError{Source: sourceOrDefault(source), What: "decode template registry", Err: err}
 	}
 
 	if err := ValidateRegistry(registry); err != nil {
-		return Registry{}, err
+		return Registry{}, SourceError{Source: sourceOrDefault(source), What: "validate template registry", Err: err}
 	}
 
 	return registry, nil
@@ -115,16 +130,16 @@ func (f SourceFetcher) LoadRegistry(ctx context.Context, source string) (Registr
 func (f SourceFetcher) LoadPack(ctx context.Context, source string) (Pack, error) {
 	payload, err := f.readManifest(ctx, source, packFileName)
 	if err != nil {
-		return Pack{}, err
+		return Pack{}, SourceError{Source: source, What: "read template pack", Err: err}
 	}
 
 	var pack Pack
 	if err := yaml.Unmarshal(payload, &pack); err != nil {
-		return Pack{}, fmt.Errorf("decode pack: %w", err)
+		return Pack{}, SourceError{Source: source, What: "decode template pack", Err: err}
 	}
 
 	if err := ValidatePack(pack); err != nil {
-		return Pack{}, err
+		return Pack{}, SourceError{Source: source, What: "validate template pack", Err: err}
 	}
 
 	return pack, nil
@@ -134,16 +149,16 @@ func (f SourceFetcher) LoadPack(ctx context.Context, source string) (Pack, error
 func (f SourceFetcher) LoadTemplate(ctx context.Context, packSource string, templatePath string) (Template, error) {
 	payload, err := f.readManifest(ctx, joinSource(packSource, templatePath), templateFileName)
 	if err != nil {
-		return Template{}, err
+		return Template{}, SourceError{Source: joinSource(packSource, templatePath), What: "read template manifest", Err: err}
 	}
 
 	var template Template
 	if err := yaml.Unmarshal(payload, &template); err != nil {
-		return Template{}, fmt.Errorf("decode template: %w", err)
+		return Template{}, SourceError{Source: joinSource(packSource, templatePath), What: "decode template manifest", Err: err}
 	}
 
 	if err := ValidateTemplate(template); err != nil {
-		return Template{}, err
+		return Template{}, SourceError{Source: joinSource(packSource, templatePath), What: "validate template manifest", Err: err}
 	}
 
 	return template, nil
@@ -316,7 +331,16 @@ func readLocalManifest(root string, manifest string) ([]byte, error) {
 		return nil, errors.New("local source path is required")
 	}
 
-	return os.ReadFile(filepath.Join(root, manifest))
+	path := filepath.Join(root, manifest)
+	payload, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("%s not found; check the source path and expected manifest name", path)
+		}
+		return nil, err
+	}
+
+	return payload, nil
 }
 
 func githubRawURL(repo string, manifest string) string {
@@ -345,4 +369,11 @@ func joinSource(source string, child string) string {
 	default:
 		return filepath.Join(source, child)
 	}
+}
+
+func sourceOrDefault(source string) string {
+	if source == "" {
+		return DefaultRegistrySource
+	}
+	return source
 }

--- a/internal/templatecatalog/catalog_test.go
+++ b/internal/templatecatalog/catalog_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -164,6 +165,58 @@ func TestValidateRegistryRejectsMissingPacks(t *testing.T) {
 
 	if err == nil {
 		t.Fatal("expected error")
+	}
+}
+
+func TestLoadRegistryWrapsDecodeErrors(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, registryFileName, `apiVersion: [`)
+
+	_, err := SourceFetcher{}.LoadRegistry(context.Background(), root)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "decode template registry") {
+		t.Fatalf("expected decode context, got %v", err)
+	}
+}
+
+func TestLoadPackWrapsMissingManifest(t *testing.T) {
+	root := t.TempDir()
+
+	_, err := SourceFetcher{}.LoadPack(context.Background(), root)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	for _, want := range []string{"read template pack", "galaxio-pack.yaml", "not found"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("expected error to contain %q, got %v", want, err)
+		}
+	}
+}
+
+func TestLoadTemplateWrapsValidationErrors(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "fake"), templateFileName, `apiVersion: galaxio.io/v1
+kind: Template
+name: fake
+engine: wrong
+inputs:
+  Name:
+    type: string
+files:
+  - from: files
+    to: .
+`)
+
+	_, err := SourceFetcher{}.LoadTemplate(context.Background(), root, "fake")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	for _, want := range []string{"validate template manifest", "template engine must be go-template"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("expected error to contain %q, got %v", want, err)
+		}
 	}
 }
 

--- a/internal/templatecatalog/catalog_test.go
+++ b/internal/templatecatalog/catalog_test.go
@@ -2,6 +2,7 @@ package templatecatalog
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -33,7 +34,7 @@ packs:
 	}
 }
 
-func TestListPacksFromRegistry(t *testing.T) {
+func TestListTemplatesFromRegistry(t *testing.T) {
 	packRoot := t.TempDir()
 	writeGatlingPack(t, packRoot)
 
@@ -45,21 +46,63 @@ packs:
     source: local:%s
 `, packRoot))
 
-	packs, err := SourceFetcher{}.ListPacks(context.Background(), registryRoot)
+	templates, err := SourceFetcher{}.ListTemplates(context.Background(), registryRoot)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
-	if len(packs) != 1 {
-		t.Fatalf("expected one pack, got %d", len(packs))
+	if len(templates) != 1 {
+		t.Fatalf("expected one template, got %d", len(templates))
 	}
-	if packs[0].Name != "gatling/scala-sbt" {
-		t.Fatalf("expected gatling/scala-sbt, got %q", packs[0].Name)
+	if templates[0].Name != "gatling/scala-sbt" {
+		t.Fatalf("expected gatling/scala-sbt, got %q", templates[0].Name)
 	}
-	if packs[0].Version != "0.1.0" {
-		t.Fatalf("expected version 0.1.0, got %q", packs[0].Version)
+	if templates[0].Version != "0.1.0" {
+		t.Fatalf("expected version 0.1.0, got %q", templates[0].Version)
 	}
-	if !packs[0].Placeholder {
+	if !templates[0].Placeholder {
 		t.Fatal("expected placeholder template")
+	}
+}
+
+func TestFindTemplateFromRegistry(t *testing.T) {
+	packRoot := t.TempDir()
+	writeGatlingPack(t, packRoot)
+
+	registryRoot := t.TempDir()
+	writeFile(t, registryRoot, registryFileName, fmt.Sprintf(`apiVersion: galaxio.io/v1
+kind: TemplateRegistry
+packs:
+  - name: gatling
+    source: local:%s
+`, packRoot))
+
+	template, err := SourceFetcher{}.FindTemplate(context.Background(), registryRoot, "gatling/scala-sbt")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if template.Name != "gatling/scala-sbt" {
+		t.Fatalf("expected gatling/scala-sbt, got %q", template.Name)
+	}
+	if template.Source != "local:"+packRoot {
+		t.Fatalf("expected source local:%s, got %q", packRoot, template.Source)
+	}
+}
+
+func TestFindTemplateReportsMissingTemplate(t *testing.T) {
+	packRoot := t.TempDir()
+	writeGatlingPack(t, packRoot)
+
+	registryRoot := t.TempDir()
+	writeFile(t, registryRoot, registryFileName, fmt.Sprintf(`apiVersion: galaxio.io/v1
+kind: TemplateRegistry
+packs:
+  - name: gatling
+    source: local:%s
+`, packRoot))
+
+	_, err := SourceFetcher{}.FindTemplate(context.Background(), registryRoot, "missing/template")
+	if !errors.Is(err, ErrTemplateNotFound) {
+		t.Fatalf("expected ErrTemplateNotFound, got %v", err)
 	}
 }
 

--- a/internal/templatecatalog/catalog_test.go
+++ b/internal/templatecatalog/catalog_test.go
@@ -55,6 +55,9 @@ packs:
 	if packs[0].Name != "gatling/scala-sbt" {
 		t.Fatalf("expected gatling/scala-sbt, got %q", packs[0].Name)
 	}
+	if packs[0].Version != "0.1.0" {
+		t.Fatalf("expected version 0.1.0, got %q", packs[0].Version)
+	}
 	if !packs[0].Placeholder {
 		t.Fatal("expected placeholder template")
 	}


### PR DESCRIPTION
## Summary

- Raise the CI coverage threshold from 30% to 65%.
- Add command-level tests for `template list`, `template init`, `template validate`, and `doctor`.
- Add catalog error-context tests for registry, pack, and template manifest failures.
- Wrap catalog loading errors with user-facing context so CLI errors explain what failed.
- Add `--output text|json` for CI-friendly machine-readable output on `version`, `update`, `template list`, `template init`, `template validate`, and `doctor`.
- Show the template pack version in `template list` instead of placeholder status text.
- Refactor template commands so `template init` resolves templates from the configured registry and YAML manifests instead of returning a hardcoded placeholder response for any name.
- Replace ad-hoc JSON maps/writes with typed response structs and a shared JSON writer helper.

## CI output examples

```sh
galaxio version --output json
galaxio template list --output json
galaxio template init gatling/scala-sbt --output json
galaxio template validate local:/path/to/pack --output json
galaxio doctor --output json
```

## Validation

- `go test ./...`
- `go vet ./...`
- `go test -race -coverprofile=coverage.out ./...`
- Local coverage threshold check: `coverage 77.8% meets required 65.0%`
- `go build -trimpath -o bin/galaxio ./cmd/galaxio`
- local smoke for `template list`, `template init`, `template init --output json`, and unknown-template usage failure using a local registry manifest
