### PR TITLE
fix(template): show placeholder status without template version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,5 +30,5 @@ go.work.sum
 .env
 
 # Editor/IDE
-# .idea/
+.idea/
 # .vscode/

--- a/cmd/galaxio/root_test.go
+++ b/cmd/galaxio/root_test.go
@@ -78,7 +78,7 @@ func TestTemplateInitPrintsComingSoon(t *testing.T) {
 	if stderr != "" {
 		t.Fatalf("expected empty stderr, got %q", stderr)
 	}
-	if want := "Template gatling/scala-sbt 0.1.0 is coming soon"; !strings.Contains(stdout, want) {
+	if want := "Template gatling/scala-sbt is coming soon"; !strings.Contains(stdout, want) {
 		t.Fatalf("expected coming soon output %q, got %q", want, stdout)
 	}
 }

--- a/cmd/galaxio/template.go
+++ b/cmd/galaxio/template.go
@@ -108,17 +108,18 @@ func newTemplateInitCommand() *cobra.Command {
 
 			if output == outputJSON {
 				if err := writeJSON(cmd.OutOrStdout(), templateInitOutput{
-					Template: template.Name,
-					Version:  template.Version,
-					Source:   template.Source,
-					Status:   templateInitStatusComingSoon,
+					Template:    template.Name,
+					Version:     template.Version,
+					PackVersion: template.PackVersion,
+					Source:      template.Source,
+					Status:      templateInitStatusComingSoon,
 				}); err != nil {
 					return RuntimeError{Err: err}
 				}
 				return nil
 			}
 
-			_, err = fmt.Fprintf(cmd.OutOrStdout(), "Template %s %s is coming soon\n", template.Name, template.Version)
+			_, err = fmt.Fprintf(cmd.OutOrStdout(), "Template %s is coming soon\n", template.Name)
 			if err != nil {
 				return RuntimeError{Err: err}
 			}
@@ -182,10 +183,11 @@ func newTemplateValidateCommand() *cobra.Command {
 const templateInitStatusComingSoon = "coming_soon"
 
 type templateInitOutput struct {
-	Template string `json:"template"`
-	Version  string `json:"version"`
-	Source   string `json:"source"`
-	Status   string `json:"status"`
+	Template    string `json:"template"`
+	Version     string `json:"version,omitempty"`
+	PackVersion string `json:"packVersion"`
+	Source      string `json:"source"`
+	Status      string `json:"status"`
 }
 
 type templateValidateOutput struct {
@@ -195,16 +197,27 @@ type templateValidateOutput struct {
 
 func writeTemplateList(writer io.Writer, templates []templatecatalog.TemplateRef) error {
 	for _, template := range templates {
+		version := templateListVersion(template)
 		if template.Description == "" {
-			if _, err := fmt.Fprintf(writer, "%s\t%s\t%s\n", template.Name, template.Version, template.Source); err != nil {
+			if _, err := fmt.Fprintf(writer, "%s\t%s\t%s\n", template.Name, version, template.Source); err != nil {
 				return err
 			}
 			continue
 		}
-		if _, err := fmt.Fprintf(writer, "%s\t%s\t%s\t%s\n", template.Name, template.Version, template.Source, template.Description); err != nil {
+		if _, err := fmt.Fprintf(writer, "%s\t%s\t%s\t%s\n", template.Name, version, template.Source, template.Description); err != nil {
 			return err
 		}
 	}
 
 	return nil
+}
+
+func templateListVersion(template templatecatalog.TemplateRef) string {
+	if template.Version != "" {
+		return template.Version
+	}
+	if template.Placeholder {
+		return "coming soon"
+	}
+	return template.PackVersion
 }

--- a/cmd/galaxio/template_command_test.go
+++ b/cmd/galaxio/template_command_test.go
@@ -19,13 +19,13 @@ func TestTemplateListWithLocalRegistry(t *testing.T) {
 	if stderr != "" {
 		t.Fatalf("expected empty stderr, got %q", stderr)
 	}
-	for _, want := range []string{"gatling/scala-sbt", "0.1.0", "local:" + packRoot, "Gatling Scala project with sbt"} {
+	for _, want := range []string{"gatling/scala-sbt", "coming soon", "local:" + packRoot, "Gatling Scala project with sbt"} {
 		if !strings.Contains(stdout, want) {
 			t.Fatalf("expected output to contain %q, got %q", want, stdout)
 		}
 	}
-	if strings.Contains(stdout, "coming soon") {
-		t.Fatalf("expected template list to omit placeholder status, got %q", stdout)
+	if strings.Contains(stdout, "\t0.1.0\t") {
+		t.Fatalf("expected placeholder template list to omit pack version, got %q", stdout)
 	}
 }
 
@@ -44,6 +44,7 @@ func TestTemplateListWithJSONOutput(t *testing.T) {
 	var refs []struct {
 		Name        string `json:"name"`
 		Pack        string `json:"pack"`
+		PackVersion string `json:"packVersion"`
 		Version     string `json:"version"`
 		Source      string `json:"source"`
 		Description string `json:"description"`
@@ -63,8 +64,11 @@ func TestTemplateListWithJSONOutput(t *testing.T) {
 	if ref.Pack != "gatling" {
 		t.Fatalf("expected pack gatling, got %q", ref.Pack)
 	}
-	if ref.Version != "0.1.0" {
-		t.Fatalf("expected version 0.1.0, got %q", ref.Version)
+	if ref.PackVersion != "0.1.0" {
+		t.Fatalf("expected pack version 0.1.0, got %q", ref.PackVersion)
+	}
+	if ref.Version != "" {
+		t.Fatalf("expected placeholder template version to be empty, got %q", ref.Version)
 	}
 	if ref.Source != "local:"+packRoot {
 		t.Fatalf("expected source local:%s, got %q", packRoot, ref.Source)
@@ -195,10 +199,11 @@ func TestTemplateInitWithJSONOutput(t *testing.T) {
 	}
 
 	var result struct {
-		Template string `json:"template"`
-		Version  string `json:"version"`
-		Source   string `json:"source"`
-		Status   string `json:"status"`
+		Template    string `json:"template"`
+		Version     string `json:"version"`
+		PackVersion string `json:"packVersion"`
+		Source      string `json:"source"`
+		Status      string `json:"status"`
 	}
 	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
 		t.Fatalf("decode json output: %v; output %q", err, stdout)
@@ -206,8 +211,11 @@ func TestTemplateInitWithJSONOutput(t *testing.T) {
 	if result.Template != "gatling/scala-sbt" {
 		t.Fatalf("expected template gatling/scala-sbt, got %q", result.Template)
 	}
-	if result.Version != "0.1.0" {
-		t.Fatalf("expected version 0.1.0, got %q", result.Version)
+	if result.Version != "" {
+		t.Fatalf("expected placeholder template version to be empty, got %q", result.Version)
+	}
+	if result.PackVersion != "0.1.0" {
+		t.Fatalf("expected pack version 0.1.0, got %q", result.PackVersion)
 	}
 	if result.Source != "local:"+packRoot {
 		t.Fatalf("expected source local:%s, got %q", packRoot, result.Source)

--- a/internal/templatecatalog/catalog.go
+++ b/internal/templatecatalog/catalog.go
@@ -53,6 +53,7 @@ type Pack struct {
 // PackTemplate points to one template manifest inside a pack.
 type PackTemplate struct {
 	Name        string `yaml:"name"`
+	Version     string `yaml:"version"`
 	Path        string `yaml:"path"`
 	Description string `yaml:"description"`
 }
@@ -81,7 +82,8 @@ type TemplateFile struct {
 type TemplateRef struct {
 	Name        string `json:"name"`
 	Pack        string `json:"pack"`
-	Version     string `json:"version"`
+	PackVersion string `json:"packVersion"`
+	Version     string `json:"version,omitempty"`
 	Source      string `json:"source"`
 	Description string `json:"description,omitempty"`
 	Templates   int    `json:"templates"`
@@ -186,7 +188,8 @@ func (f SourceFetcher) ListTemplates(ctx context.Context, registrySource string)
 			result = append(result, TemplateRef{
 				Name:        pack.Name + "/" + template.Name,
 				Pack:        pack.Name,
-				Version:     pack.Version,
+				PackVersion: pack.Version,
+				Version:     template.Version,
 				Source:      registryPack.Source,
 				Description: template.Description,
 				Templates:   len(pack.Templates),

--- a/internal/templatecatalog/catalog_test.go
+++ b/internal/templatecatalog/catalog_test.go
@@ -56,8 +56,11 @@ packs:
 	if templates[0].Name != "gatling/scala-sbt" {
 		t.Fatalf("expected gatling/scala-sbt, got %q", templates[0].Name)
 	}
-	if templates[0].Version != "0.1.0" {
-		t.Fatalf("expected version 0.1.0, got %q", templates[0].Version)
+	if templates[0].PackVersion != "0.1.0" {
+		t.Fatalf("expected pack version 0.1.0, got %q", templates[0].PackVersion)
+	}
+	if templates[0].Version != "" {
+		t.Fatalf("expected placeholder template version to be empty, got %q", templates[0].Version)
 	}
 	if !templates[0].Placeholder {
 		t.Fatal("expected placeholder template")
@@ -103,6 +106,52 @@ packs:
 	_, err := SourceFetcher{}.FindTemplate(context.Background(), registryRoot, "missing/template")
 	if !errors.Is(err, ErrTemplateNotFound) {
 		t.Fatalf("expected ErrTemplateNotFound, got %v", err)
+	}
+}
+
+func TestListTemplatesUsesTemplateVersionWhenPresent(t *testing.T) {
+	packRoot := t.TempDir()
+	writeFile(t, packRoot, packFileName, `apiVersion: galaxio.io/v1
+kind: TemplatePack
+name: examples
+version: 0.1.0
+templates:
+  - name: renderable
+    version: 1.2.3
+    path: renderable
+`)
+	writeFile(t, filepath.Join(packRoot, "renderable"), templateFileName, `apiVersion: galaxio.io/v1
+kind: Template
+name: renderable
+engine: go-template
+inputs:
+  Name:
+    type: string
+files:
+  - from: files
+    to: .
+`)
+
+	registryRoot := t.TempDir()
+	writeFile(t, registryRoot, registryFileName, fmt.Sprintf(`apiVersion: galaxio.io/v1
+kind: TemplateRegistry
+packs:
+  - name: examples
+    source: local:%s
+`, packRoot))
+
+	templates, err := SourceFetcher{}.ListTemplates(context.Background(), registryRoot)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if templates[0].PackVersion != "0.1.0" {
+		t.Fatalf("expected pack version 0.1.0, got %q", templates[0].PackVersion)
+	}
+	if templates[0].Version != "1.2.3" {
+		t.Fatalf("expected template version 1.2.3, got %q", templates[0].Version)
+	}
+	if templates[0].Placeholder {
+		t.Fatal("expected renderable template")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Distinguish pack version from template version in catalog output.
- Show `coming soon` in `template list` when a template is a placeholder and does not define its own `version`.
- Keep pack-level version available in JSON as `packVersion`.
- Keep template-level `version` optional and driven by `galaxio-pack.yaml` entries.

## Validation

- `go test ./...`
- `go vet ./...`
- `go test -race -coverprofile=coverage.out ./...`
- Local coverage threshold check: `coverage 77.7% meets required 65.0%`
- Local smoke against `templates-gatling`: placeholder templates show `coming soon` in text output and `packVersion: 0.1.0` in JSON.
