### PR TITLE
feat(template): render templates on init

### DIFF
--- a/cmd/galaxio/config.go
+++ b/cmd/galaxio/config.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/galax-io/galaxio-cli/internal/templatecatalog"
+	"gopkg.in/yaml.v3"
+)
+
+const configEnv = "GALAXIO_CONFIG"
+
+type config struct {
+	Template templateConfig `yaml:"template"`
+}
+
+type templateConfig struct {
+	Registry string `yaml:"registry"`
+}
+
+func configPath() (string, error) {
+	if path := os.Getenv(configEnv); path != "" {
+		return path, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".galaxio", "config.yaml"), nil
+}
+
+func loadConfig() (config, error) {
+	path, err := configPath()
+	if err != nil {
+		return config{}, err
+	}
+	payload, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return config{}, nil
+		}
+		return config{}, err
+	}
+
+	var cfg config
+	if err := yaml.Unmarshal(payload, &cfg); err != nil {
+		return config{}, err
+	}
+	return cfg, nil
+}
+
+func saveConfig(cfg config) error {
+	path, err := configPath()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	payload, err := yaml.Marshal(cfg)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, payload, 0o644)
+}
+
+func resolveTemplateRegistry(flagValue string) (string, error) {
+	if flagValue != "" {
+		return flagValue, nil
+	}
+	cfg, err := loadConfig()
+	if err != nil {
+		return "", fmt.Errorf("load config: %w", err)
+	}
+	if cfg.Template.Registry != "" {
+		return cfg.Template.Registry, nil
+	}
+	return templatecatalog.DefaultRegistrySource, nil
+}

--- a/cmd/galaxio/doctor.go
+++ b/cmd/galaxio/doctor.go
@@ -25,16 +25,20 @@ func newDoctorCommand() *cobra.Command {
 			if err := validateOutputFormat(output); err != nil {
 				return err
 			}
+			registrySource, err := resolveTemplateRegistry(registry)
+			if err != nil {
+				return RuntimeError{Err: err}
+			}
 
 			fetcher := templatecatalog.SourceFetcher{}
-			templates, err := fetcher.ListTemplates(cmd.Context(), registry)
+			templates, err := fetcher.ListTemplates(cmd.Context(), registrySource)
 			if err != nil {
 				return RuntimeError{Err: err}
 			}
 
 			if output == outputJSON {
 				if err := writeJSON(cmd.OutOrStdout(), doctorOutput{
-					Registry:        registry,
+					Registry:        registrySource,
 					Status:          "ok",
 					TemplateEntries: len(templates),
 				}); err != nil {
@@ -43,7 +47,7 @@ func newDoctorCommand() *cobra.Command {
 				return nil
 			}
 
-			_, err = fmt.Fprintf(cmd.OutOrStdout(), "OK template registry: %s\n", registry)
+			_, err = fmt.Fprintf(cmd.OutOrStdout(), "OK template registry: %s\n", registrySource)
 			if err != nil {
 				return RuntimeError{Err: err}
 			}
@@ -56,7 +60,7 @@ func newDoctorCommand() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&registry, "registry", templatecatalog.DefaultRegistrySource, "template registry source")
+	cmd.Flags().StringVar(&registry, "registry", "", "template registry source")
 	cmd.Flags().StringVarP(&output, "output", "o", outputText, "output format: text or json")
 
 	return cmd

--- a/cmd/galaxio/root_test.go
+++ b/cmd/galaxio/root_test.go
@@ -60,7 +60,7 @@ func TestTemplateCommandPrintsHelp(t *testing.T) {
 	if stderr != "" {
 		t.Fatalf("expected empty stderr, got %q", stderr)
 	}
-	for _, want := range []string{"Discover and validate", "init", "list", "validate"} {
+	for _, want := range []string{"Discover and validate", "configure", "init", "list", "validate"} {
 		if !strings.Contains(stdout, want) {
 			t.Fatalf("expected template help to contain %q, got %q", want, stdout)
 		}

--- a/cmd/galaxio/template.go
+++ b/cmd/galaxio/template.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/galax-io/galaxio-cli/internal/templatecatalog"
 	"github.com/spf13/cobra"
@@ -79,7 +80,9 @@ func newTemplateListCommand() *cobra.Command {
 
 func newTemplateInitCommand() *cobra.Command {
 	var registry string
+	var destination string
 	var output string
+	var values []string
 
 	cmd := &cobra.Command{
 		Use:   "init <template>",
@@ -95,6 +98,10 @@ func newTemplateInitCommand() *cobra.Command {
 			if err := validateOutputFormat(output); err != nil {
 				return err
 			}
+			renderValues, err := parseTemplateValues(values)
+			if err != nil {
+				return err
+			}
 			template, err := (templatecatalog.SourceFetcher{}).FindTemplate(cmd.Context(), registry, args[0])
 			if err != nil {
 				if errors.Is(err, templatecatalog.ErrTemplateNotFound) {
@@ -103,17 +110,27 @@ func newTemplateInitCommand() *cobra.Command {
 				return RuntimeError{Err: err}
 			}
 			if !template.Placeholder {
-				return RuntimeError{Err: fmt.Errorf("template %q is available, but rendering is not implemented yet", template.Name)}
+				result, err := (templatecatalog.SourceFetcher{}).Render(cmd.Context(), templatecatalog.RenderOptions{
+					RegistrySource: registry,
+					TemplateName:   args[0],
+					Destination:    destination,
+					Values:         renderValues,
+				})
+				if err != nil {
+					return RuntimeError{Err: err}
+				}
+				return printTemplateInitResult(cmd, result, output)
 			}
 
+			result := templatecatalog.RenderResult{
+				Template:    template.Name,
+				Version:     template.Version,
+				PackVersion: template.PackVersion,
+				Source:      template.Source,
+				Status:      templateInitStatusComingSoon,
+			}
 			if output == outputJSON {
-				if err := writeJSON(cmd.OutOrStdout(), templateInitOutput{
-					Template:    template.Name,
-					Version:     template.Version,
-					PackVersion: template.PackVersion,
-					Source:      template.Source,
-					Status:      templateInitStatusComingSoon,
-				}); err != nil {
+				if err := writeJSON(cmd.OutOrStdout(), result); err != nil {
 					return RuntimeError{Err: err}
 				}
 				return nil
@@ -128,7 +145,9 @@ func newTemplateInitCommand() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&registry, "registry", templatecatalog.DefaultRegistrySource, "template registry source")
+	cmd.Flags().StringVarP(&destination, "destination", "d", ".", "directory to render the template into")
 	cmd.Flags().StringVarP(&output, "output", "o", outputText, "output format: text or json")
+	cmd.Flags().StringArrayVar(&values, "set", nil, "template value in Key=Value form")
 
 	return cmd
 }
@@ -193,6 +212,26 @@ type templateInitOutput struct {
 type templateValidateOutput struct {
 	Source string `json:"source"`
 	Status string `json:"status"`
+}
+
+func printTemplateInitResult(cmd *cobra.Command, result templatecatalog.RenderResult, output string) error {
+	if output == outputJSON {
+		return writeJSON(cmd.OutOrStdout(), result)
+	}
+	_, err := fmt.Fprintf(cmd.OutOrStdout(), "Rendered %s to %s (%d files)\n", result.Template, result.Destination, result.Files)
+	return err
+}
+
+func parseTemplateValues(values []string) (map[string]string, error) {
+	result := make(map[string]string, len(values))
+	for _, value := range values {
+		key, raw, ok := strings.Cut(value, "=")
+		if !ok || key == "" {
+			return nil, UsageError{Err: fmt.Errorf("--set must use Key=Value, got %q", value)}
+		}
+		result[key] = raw
+	}
+	return result, nil
 }
 
 func writeTemplateList(writer io.Writer, templates []templatecatalog.TemplateRef) error {

--- a/cmd/galaxio/template.go
+++ b/cmd/galaxio/template.go
@@ -4,10 +4,12 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 
 	"github.com/galax-io/galaxio-cli/internal/templatecatalog"
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 )
 
 func newTemplateCommand() *cobra.Command {
@@ -27,6 +29,7 @@ func newTemplateCommand() *cobra.Command {
 	}
 
 	cmd.AddCommand(newTemplateListCommand())
+	cmd.AddCommand(newTemplateConfigureCommand())
 	cmd.AddCommand(newTemplateInitCommand())
 	cmd.AddCommand(newTemplateValidateCommand())
 
@@ -51,8 +54,12 @@ func newTemplateListCommand() *cobra.Command {
 			if err := validateOutputFormat(output); err != nil {
 				return err
 			}
+			registrySource, err := resolveTemplateRegistry(registry)
+			if err != nil {
+				return RuntimeError{Err: err}
+			}
 
-			templates, err := (templatecatalog.SourceFetcher{}).ListTemplates(cmd.Context(), registry)
+			templates, err := (templatecatalog.SourceFetcher{}).ListTemplates(cmd.Context(), registrySource)
 			if err != nil {
 				return RuntimeError{Err: err}
 			}
@@ -72,8 +79,48 @@ func newTemplateListCommand() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&registry, "registry", templatecatalog.DefaultRegistrySource, "template registry source")
+	cmd.Flags().StringVar(&registry, "registry", "", "template registry source")
 	cmd.Flags().StringVarP(&output, "output", "o", outputText, "output format: text or json")
+
+	return cmd
+}
+
+func newTemplateConfigureCommand() *cobra.Command {
+	var registry string
+	var show bool
+
+	cmd := &cobra.Command{
+		Use:   "configure",
+		Short: "Configure template registry settings.",
+		Long:  "Configure persistent template registry settings for galaxio template commands.",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if err := cobra.NoArgs(cmd, args); err != nil {
+				return UsageError{Err: err}
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if registry != "" {
+				cfg, err := loadConfig()
+				if err != nil {
+					return RuntimeError{Err: fmt.Errorf("load config: %w", err)}
+				}
+				cfg.Template.Registry = registry
+				if err := saveConfig(cfg); err != nil {
+					return RuntimeError{Err: fmt.Errorf("save config: %w", err)}
+				}
+			}
+
+			if show || registry != "" {
+				return printTemplateConfig(cmd, registry)
+			}
+
+			return printTemplateConfig(cmd, "")
+		},
+	}
+
+	cmd.Flags().StringVar(&registry, "registry", "", "template registry source")
+	cmd.Flags().BoolVar(&show, "show", false, "show current template configuration")
 
 	return cmd
 }
@@ -82,6 +129,7 @@ func newTemplateInitCommand() *cobra.Command {
 	var registry string
 	var destination string
 	var output string
+	var valuesFile string
 	var values []string
 
 	cmd := &cobra.Command{
@@ -98,11 +146,23 @@ func newTemplateInitCommand() *cobra.Command {
 			if err := validateOutputFormat(output); err != nil {
 				return err
 			}
-			renderValues, err := parseTemplateValues(values)
+			registrySource, err := resolveTemplateRegistry(registry)
+			if err != nil {
+				return RuntimeError{Err: err}
+			}
+			renderValues, err := loadTemplateValues(valuesFile)
 			if err != nil {
 				return err
 			}
-			template, err := (templatecatalog.SourceFetcher{}).FindTemplate(cmd.Context(), registry, args[0])
+			setValues, err := parseTemplateValues(values)
+			if err != nil {
+				return err
+			}
+			for key, value := range setValues {
+				renderValues[key] = value
+			}
+
+			template, err := (templatecatalog.SourceFetcher{}).FindTemplate(cmd.Context(), registrySource, args[0])
 			if err != nil {
 				if errors.Is(err, templatecatalog.ErrTemplateNotFound) {
 					return UsageError{Err: err}
@@ -111,7 +171,7 @@ func newTemplateInitCommand() *cobra.Command {
 			}
 			if !template.Placeholder {
 				result, err := (templatecatalog.SourceFetcher{}).Render(cmd.Context(), templatecatalog.RenderOptions{
-					RegistrySource: registry,
+					RegistrySource: registrySource,
 					TemplateName:   args[0],
 					Destination:    destination,
 					Values:         renderValues,
@@ -144,9 +204,10 @@ func newTemplateInitCommand() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&registry, "registry", templatecatalog.DefaultRegistrySource, "template registry source")
+	cmd.Flags().StringVar(&registry, "registry", "", "template registry source")
 	cmd.Flags().StringVarP(&destination, "destination", "d", ".", "directory to render the template into")
 	cmd.Flags().StringVarP(&output, "output", "o", outputText, "output format: text or json")
+	cmd.Flags().StringVar(&valuesFile, "values", "", "YAML file with template values")
 	cmd.Flags().StringArrayVar(&values, "set", nil, "template value in Key=Value form")
 
 	return cmd
@@ -214,12 +275,51 @@ type templateValidateOutput struct {
 	Status string `json:"status"`
 }
 
+func printTemplateConfig(cmd *cobra.Command, override string) error {
+	path, err := configPath()
+	if err != nil {
+		return RuntimeError{Err: err}
+	}
+	registry, err := resolveTemplateRegistry(override)
+	if err != nil {
+		return RuntimeError{Err: err}
+	}
+	if _, err := fmt.Fprintf(cmd.OutOrStdout(), "config: %s\n", path); err != nil {
+		return RuntimeError{Err: err}
+	}
+	if _, err := fmt.Fprintf(cmd.OutOrStdout(), "registry: %s\n", registry); err != nil {
+		return RuntimeError{Err: err}
+	}
+	return nil
+}
+
 func printTemplateInitResult(cmd *cobra.Command, result templatecatalog.RenderResult, output string) error {
 	if output == outputJSON {
 		return writeJSON(cmd.OutOrStdout(), result)
 	}
 	_, err := fmt.Fprintf(cmd.OutOrStdout(), "Rendered %s to %s (%d files)\n", result.Template, result.Destination, result.Files)
 	return err
+}
+
+func loadTemplateValues(path string) (map[string]string, error) {
+	if path == "" {
+		return map[string]string{}, nil
+	}
+	payload, err := os.ReadFile(path)
+	if err != nil {
+		return nil, UsageError{Err: fmt.Errorf("read values file %q: %w", path, err)}
+	}
+
+	values := map[string]any{}
+	if err := yaml.Unmarshal(payload, &values); err != nil {
+		return nil, UsageError{Err: fmt.Errorf("decode values file %q: %w", path, err)}
+	}
+
+	result := make(map[string]string, len(values))
+	for key, value := range values {
+		result[key] = fmt.Sprint(value)
+	}
+	return result, nil
 }
 
 func parseTemplateValues(values []string) (map[string]string, error) {

--- a/cmd/galaxio/template_command_test.go
+++ b/cmd/galaxio/template_command_test.go
@@ -84,6 +84,76 @@ func TestTemplateListWithJSONOutput(t *testing.T) {
 	}
 }
 
+func TestTemplateListUsesConfiguredRegistry(t *testing.T) {
+	registryRoot, packRoot := writeTemplateCatalogFixture(t)
+	t.Setenv(configEnv, filepath.Join(t.TempDir(), "config.yaml"))
+
+	code, stdout, stderr := runCLI("template", "configure", "--registry", "local:"+registryRoot)
+	if code != exitOK {
+		t.Fatalf("expected configure exit code %d, got %d, stderr %q", exitOK, code, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty configure stderr, got %q", stderr)
+	}
+
+	code, stdout, stderr = runCLI("template", "list")
+	if code != exitOK {
+		t.Fatalf("expected list exit code %d, got %d, stderr %q", exitOK, code, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty list stderr, got %q", stderr)
+	}
+	for _, want := range []string{"gatling/scala-sbt", "local:" + packRoot} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("expected configured registry output to contain %q, got %q", want, stdout)
+		}
+	}
+}
+
+func TestTemplateConfigureShowsDefaultRegistry(t *testing.T) {
+	configFile := filepath.Join(t.TempDir(), "config.yaml")
+	t.Setenv(configEnv, configFile)
+
+	code, stdout, stderr := runCLI("template", "configure", "--show")
+
+	if code != exitOK {
+		t.Fatalf("expected exit code %d, got %d, stderr %q", exitOK, code, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	for _, want := range []string{"config: " + configFile, "registry: github:galax-io/galaxio-template-registry"} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("expected configure output to contain %q, got %q", want, stdout)
+		}
+	}
+}
+
+func TestTemplateConfigureWritesRegistry(t *testing.T) {
+	configFile := filepath.Join(t.TempDir(), "config.yaml")
+	t.Setenv(configEnv, configFile)
+
+	code, stdout, stderr := runCLI("template", "configure", "--registry", "github:my-org/my-template-registry")
+
+	if code != exitOK {
+		t.Fatalf("expected exit code %d, got %d, stderr %q", exitOK, code, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, "registry: github:my-org/my-template-registry") {
+		t.Fatalf("expected written registry in output, got %q", stdout)
+	}
+
+	payload, err := os.ReadFile(configFile)
+	if err != nil {
+		t.Fatalf("read config file: %v", err)
+	}
+	if !strings.Contains(string(payload), "registry: github:my-org/my-template-registry") {
+		t.Fatalf("expected config file to contain registry, got %q", payload)
+	}
+}
+
 func TestTemplateListReportsMissingRegistry(t *testing.T) {
 	missing := filepath.Join(t.TempDir(), "missing")
 
@@ -312,6 +382,78 @@ func TestTemplateInitRendersJSONOutput(t *testing.T) {
 	}
 	if result.Status != "rendered" {
 		t.Fatalf("expected rendered status, got %q", result.Status)
+	}
+}
+
+func TestTemplateInitRendersValuesFile(t *testing.T) {
+	registryRoot, _ := writeRenderableTemplateCatalogFixture(t)
+	destination := t.TempDir()
+	valuesFile := filepath.Join(t.TempDir(), "values.yaml")
+	writeTestFile(t, filepath.Dir(valuesFile), filepath.Base(valuesFile), "Name: payments\n")
+
+	code, stdout, stderr := runCLI(
+		"template",
+		"init",
+		"examples/service",
+		"--registry",
+		"local:"+registryRoot,
+		"--destination",
+		destination,
+		"--values",
+		valuesFile,
+	)
+
+	if code != exitOK {
+		t.Fatalf("expected exit code %d, got %d, stderr %q", exitOK, code, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, "Rendered examples/service to ") {
+		t.Fatalf("expected render summary, got %q", stdout)
+	}
+
+	payload, err := os.ReadFile(filepath.Join(destination, "payments.txt"))
+	if err != nil {
+		t.Fatalf("read rendered file: %v", err)
+	}
+	if string(payload) != "hello payments\n" {
+		t.Fatalf("expected rendered values file payload, got %q", payload)
+	}
+}
+
+func TestTemplateInitSetOverridesValuesFile(t *testing.T) {
+	registryRoot, _ := writeRenderableTemplateCatalogFixture(t)
+	destination := t.TempDir()
+	valuesFile := filepath.Join(t.TempDir(), "values.yaml")
+	writeTestFile(t, filepath.Dir(valuesFile), filepath.Base(valuesFile), "Name: payments\n")
+
+	code, _, stderr := runCLI(
+		"template",
+		"init",
+		"examples/service",
+		"--registry",
+		"local:"+registryRoot,
+		"--destination",
+		destination,
+		"--values",
+		valuesFile,
+		"--set",
+		"Name=orders",
+	)
+
+	if code != exitOK {
+		t.Fatalf("expected exit code %d, got %d, stderr %q", exitOK, code, stderr)
+	}
+	payload, err := os.ReadFile(filepath.Join(destination, "orders.txt"))
+	if err != nil {
+		t.Fatalf("read rendered file: %v", err)
+	}
+	if string(payload) != "hello orders\n" {
+		t.Fatalf("expected --set override payload, got %q", payload)
+	}
+	if _, err := os.Stat(filepath.Join(destination, "payments.txt")); !os.IsNotExist(err) {
+		t.Fatalf("expected values-only file to be absent, stat err %v", err)
 	}
 }
 

--- a/cmd/galaxio/template_command_test.go
+++ b/cmd/galaxio/template_command_test.go
@@ -225,6 +225,112 @@ func TestTemplateInitWithJSONOutput(t *testing.T) {
 	}
 }
 
+func TestTemplateInitRendersLocalTemplate(t *testing.T) {
+	registryRoot, _ := writeRenderableTemplateCatalogFixture(t)
+	destination := t.TempDir()
+
+	code, stdout, stderr := runCLI(
+		"template",
+		"init",
+		"examples/service",
+		"--registry",
+		"local:"+registryRoot,
+		"--destination",
+		destination,
+		"--set",
+		"Name=orders",
+	)
+
+	if code != exitOK {
+		t.Fatalf("expected exit code %d, got %d, stderr %q", exitOK, code, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, "Rendered examples/service to ") {
+		t.Fatalf("expected render summary, got %q", stdout)
+	}
+
+	renderedPath := filepath.Join(destination, "orders.txt")
+	payload, err := os.ReadFile(renderedPath)
+	if err != nil {
+		t.Fatalf("read rendered file: %v", err)
+	}
+	if string(payload) != "hello orders\n" {
+		t.Fatalf("expected rendered payload, got %q", payload)
+	}
+}
+
+func TestTemplateInitRendersJSONOutput(t *testing.T) {
+	registryRoot, _ := writeRenderableTemplateCatalogFixture(t)
+	destination := t.TempDir()
+
+	code, stdout, stderr := runCLI(
+		"template",
+		"init",
+		"examples/service",
+		"--registry",
+		"local:"+registryRoot,
+		"--destination",
+		destination,
+		"--output",
+		"json",
+	)
+
+	if code != exitOK {
+		t.Fatalf("expected exit code %d, got %d, stderr %q", exitOK, code, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var result struct {
+		Template    string `json:"template"`
+		Version     string `json:"version"`
+		PackVersion string `json:"packVersion"`
+		Destination string `json:"destination"`
+		Files       int    `json:"files"`
+		Status      string `json:"status"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("decode json output: %v; output %q", err, stdout)
+	}
+	if result.Template != "examples/service" {
+		t.Fatalf("expected template examples/service, got %q", result.Template)
+	}
+	if result.Version != "1.2.3" {
+		t.Fatalf("expected version 1.2.3, got %q", result.Version)
+	}
+	if result.PackVersion != "0.1.0" {
+		t.Fatalf("expected pack version 0.1.0, got %q", result.PackVersion)
+	}
+	if result.Destination == "" {
+		t.Fatalf("expected destination in result, got %#v", result)
+	}
+	if result.Files != 1 {
+		t.Fatalf("expected one rendered file, got %d", result.Files)
+	}
+	if result.Status != "rendered" {
+		t.Fatalf("expected rendered status, got %q", result.Status)
+	}
+}
+
+func TestTemplateInitRejectsInvalidSetValue(t *testing.T) {
+	registryRoot, _ := writeRenderableTemplateCatalogFixture(t)
+
+	code, stdout, stderr := runCLI("template", "init", "examples/service", "--registry", "local:"+registryRoot, "--set", "Name")
+
+	if code != exitUsage {
+		t.Fatalf("expected exit code %d, got %d", exitUsage, code)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "--set must use Key=Value") {
+		t.Fatalf("expected invalid set error, got %q", stderr)
+	}
+}
+
 func TestTemplateInitReportsUnknownTemplate(t *testing.T) {
 	registryRoot, _ := writeTemplateCatalogFixture(t)
 
@@ -323,6 +429,45 @@ func TestTemplateInitRequiresTemplateName(t *testing.T) {
 	if !strings.Contains(stderr, "accepts 1 arg") {
 		t.Fatalf("expected argument validation error, got %q", stderr)
 	}
+}
+
+func writeRenderableTemplateCatalogFixture(t *testing.T) (string, string) {
+	t.Helper()
+
+	packRoot := t.TempDir()
+	writeTestFile(t, packRoot, "galaxio-pack.yaml", `apiVersion: galaxio.io/v1
+kind: TemplatePack
+name: examples
+version: 0.1.0
+templates:
+  - name: service
+    version: 1.2.3
+    path: service
+    description: Example service
+`)
+	writeTestFile(t, packRoot, "service/galaxio-template.yaml", `apiVersion: galaxio.io/v1
+kind: Template
+name: service
+engine: go-template
+inputs:
+  Name:
+    type: string
+    default: default
+files:
+  - from: files
+    to: .
+`)
+	writeTestFile(t, packRoot, "service/files/{{ .Name }}.txt", "hello {{ .Name }}\n")
+
+	registryRoot := t.TempDir()
+	writeTestFile(t, registryRoot, "galaxio-registry.yaml", `apiVersion: galaxio.io/v1
+kind: TemplateRegistry
+packs:
+  - name: examples
+    source: local:`+packRoot+`
+`)
+
+	return registryRoot, packRoot
 }
 
 func writeTemplateCatalogFixture(t *testing.T) (string, string) {

--- a/internal/templatecatalog/catalog.go
+++ b/internal/templatecatalog/catalog.go
@@ -3,6 +3,8 @@
 package templatecatalog
 
 import (
+	"archive/zip"
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -11,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"text/template"
 
 	"gopkg.in/yaml.v3"
 )
@@ -58,18 +61,25 @@ type PackTemplate struct {
 	Description string `yaml:"description"`
 }
 
+// TemplateInput describes one configurable template input.
+type TemplateInput struct {
+	Type        string `yaml:"type"`
+	Default     any    `yaml:"default"`
+	Description string `yaml:"description"`
+}
+
 // Template describes one renderable template.
 type Template struct {
-	APIVersion  string            `yaml:"apiVersion"`
-	Kind        string            `yaml:"kind"`
-	Name        string            `yaml:"name"`
-	DisplayName string            `yaml:"displayName"`
-	Description string            `yaml:"description"`
-	Engine      string            `yaml:"engine"`
-	Tags        []string          `yaml:"tags"`
-	Inputs      map[string]any    `yaml:"inputs"`
-	Computed    map[string]string `yaml:"computed"`
-	Files       []TemplateFile    `yaml:"files"`
+	APIVersion  string                   `yaml:"apiVersion"`
+	Kind        string                   `yaml:"kind"`
+	Name        string                   `yaml:"name"`
+	DisplayName string                   `yaml:"displayName"`
+	Description string                   `yaml:"description"`
+	Engine      string                   `yaml:"engine"`
+	Tags        []string                 `yaml:"tags"`
+	Inputs      map[string]TemplateInput `yaml:"inputs"`
+	Computed    map[string]string        `yaml:"computed"`
+	Files       []TemplateFile           `yaml:"files"`
 }
 
 // TemplateFile describes one file mapping in a template.
@@ -84,10 +94,30 @@ type TemplateRef struct {
 	Pack        string `json:"pack"`
 	PackVersion string `json:"packVersion"`
 	Version     string `json:"version,omitempty"`
+	Path        string `json:"-"`
 	Source      string `json:"source"`
 	Description string `json:"description,omitempty"`
 	Templates   int    `json:"templates"`
 	Placeholder bool   `json:"placeholder"`
+}
+
+// RenderOptions configures template rendering.
+type RenderOptions struct {
+	RegistrySource string
+	TemplateName   string
+	Destination    string
+	Values         map[string]string
+}
+
+// RenderResult describes rendered template output.
+type RenderResult struct {
+	Template    string `json:"template"`
+	Version     string `json:"version,omitempty"`
+	PackVersion string `json:"packVersion"`
+	Source      string `json:"source"`
+	Destination string `json:"destination"`
+	Files       int    `json:"files"`
+	Status      string `json:"status"`
 }
 
 // SourceFetcher loads manifest files from local paths or remote sources.
@@ -190,6 +220,7 @@ func (f SourceFetcher) ListTemplates(ctx context.Context, registrySource string)
 				Pack:        pack.Name,
 				PackVersion: pack.Version,
 				Version:     template.Version,
+				Path:        template.Path,
 				Source:      registryPack.Source,
 				Description: template.Description,
 				Templates:   len(pack.Templates),
@@ -199,6 +230,53 @@ func (f SourceFetcher) ListTemplates(ctx context.Context, registrySource string)
 	}
 
 	return result, nil
+}
+
+// Render resolves a template from a registry and renders it into a destination.
+func (f SourceFetcher) Render(ctx context.Context, opts RenderOptions) (RenderResult, error) {
+	ref, err := f.FindTemplate(ctx, opts.RegistrySource, opts.TemplateName)
+	if err != nil {
+		return RenderResult{}, err
+	}
+	if ref.Path == "" {
+		return RenderResult{}, fmt.Errorf("template %q is coming soon", ref.Name)
+	}
+
+	manifest, err := f.LoadTemplate(ctx, ref.Source, ref.Path)
+	if err != nil {
+		return RenderResult{}, err
+	}
+
+	sourceRoot, cleanup, err := f.materializeSource(ctx, ref.Source)
+	if err != nil {
+		return RenderResult{}, err
+	}
+	defer cleanup()
+
+	destination := opts.Destination
+	if destination == "" {
+		destination = "."
+	}
+	absDestination, err := filepath.Abs(destination)
+	if err != nil {
+		return RenderResult{}, err
+	}
+
+	data := templateData(manifest, opts.Values)
+	files, err := renderTemplateFiles(filepath.Join(sourceRoot, filepath.FromSlash(ref.Path)), absDestination, manifest, data)
+	if err != nil {
+		return RenderResult{}, err
+	}
+
+	return RenderResult{
+		Template:    ref.Name,
+		Version:     ref.Version,
+		PackVersion: ref.PackVersion,
+		Source:      ref.Source,
+		Destination: absDestination,
+		Files:       files,
+		Status:      "rendered",
+	}, nil
 }
 
 // FindTemplate resolves a template reference from a registry.
@@ -351,6 +429,60 @@ func (f SourceFetcher) readURL(ctx context.Context, url string) ([]byte, error) 
 	return io.ReadAll(resp.Body)
 }
 
+func (f SourceFetcher) materializeSource(ctx context.Context, source string) (string, func(), error) {
+	switch {
+	case strings.HasPrefix(source, "local:"):
+		return strings.TrimPrefix(source, "local:"), func() {}, nil
+	case strings.HasPrefix(source, "github:"):
+		return f.materializeGitHubSource(ctx, strings.TrimPrefix(source, "github:"))
+	case strings.HasPrefix(source, "http://") || strings.HasPrefix(source, "https://"):
+		return "", nil, fmt.Errorf("rendering from URL sources is not supported yet")
+	default:
+		return source, func() {}, nil
+	}
+}
+
+func (f SourceFetcher) materializeGitHubSource(ctx context.Context, repo string) (string, func(), error) {
+	owner, name, subpath, err := parseGitHubSource(repo)
+	if err != nil {
+		return "", nil, err
+	}
+	payload, err := f.readURL(ctx, fmt.Sprintf("https://codeload.github.com/%s/%s/zip/refs/heads/main", owner, name))
+	if err != nil {
+		return "", nil, err
+	}
+
+	tempDir, err := os.MkdirTemp("", "galaxio-template-*")
+	if err != nil {
+		return "", nil, err
+	}
+	cleanup := func() {
+		_ = os.RemoveAll(tempDir)
+	}
+
+	reader, err := zip.NewReader(bytes.NewReader(payload), int64(len(payload)))
+	if err != nil {
+		cleanup()
+		return "", nil, err
+	}
+	if err := extractZip(reader, tempDir); err != nil {
+		cleanup()
+		return "", nil, err
+	}
+
+	entries, err := os.ReadDir(tempDir)
+	if err != nil {
+		cleanup()
+		return "", nil, err
+	}
+	if len(entries) != 1 || !entries[0].IsDir() {
+		cleanup()
+		return "", nil, fmt.Errorf("unexpected GitHub archive layout for %q", repo)
+	}
+
+	return filepath.Join(tempDir, entries[0].Name(), filepath.FromSlash(subpath)), cleanup, nil
+}
+
 func readLocalManifest(root string, manifest string) ([]byte, error) {
 	if root == "" {
 		return nil, errors.New("local source path is required")
@@ -380,6 +512,151 @@ func githubRawURL(repo string, manifest string) string {
 	}
 
 	return "https://raw.githubusercontent.com/" + parts[0] + "/" + parts[1] + "/main/" + path + manifest
+}
+
+func parseGitHubSource(repo string) (string, string, string, error) {
+	parts := strings.Split(strings.Trim(repo, "/"), "/")
+	if len(parts) < 2 {
+		return "", "", "", fmt.Errorf("github source must be owner/repo, got %q", repo)
+	}
+	subpath := ""
+	if len(parts) > 2 {
+		subpath = strings.Join(parts[2:], "/")
+	}
+	return parts[0], parts[1], subpath, nil
+}
+
+func extractZip(reader *zip.Reader, destination string) error {
+	for _, file := range reader.File {
+		target := filepath.Join(destination, filepath.Clean(file.Name))
+		if !strings.HasPrefix(target, filepath.Clean(destination)+string(os.PathSeparator)) {
+			return fmt.Errorf("zip entry escapes destination: %s", file.Name)
+		}
+		if file.FileInfo().IsDir() {
+			if err := os.MkdirAll(target, 0o755); err != nil {
+				return err
+			}
+			continue
+		}
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return err
+		}
+		source, err := file.Open()
+		if err != nil {
+			return err
+		}
+		if err := copyFile(target, source, file.FileInfo().Mode()); err != nil {
+			_ = source.Close()
+			return err
+		}
+		if err := source.Close(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func copyFile(path string, source io.Reader, mode os.FileMode) error {
+	target, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, mode)
+	if err != nil {
+		return err
+	}
+	defer target.Close()
+	_, err = io.Copy(target, source)
+	return err
+}
+
+func templateData(manifest Template, overrides map[string]string) map[string]any {
+	data := make(map[string]any, len(manifest.Inputs))
+	for name, input := range manifest.Inputs {
+		data[name] = input.Default
+	}
+	for name, value := range overrides {
+		data[name] = value
+	}
+	return data
+}
+
+func renderTemplateFiles(templateRoot string, destination string, manifest Template, data map[string]any) (int, error) {
+	var rendered int
+	for _, mapping := range manifest.Files {
+		sourceRoot := filepath.Join(templateRoot, filepath.FromSlash(mapping.From))
+		targetRoot := filepath.Join(destination, filepath.FromSlash(mapping.To))
+		count, err := renderTree(sourceRoot, targetRoot, data)
+		if err != nil {
+			return 0, err
+		}
+		rendered += count
+	}
+	return rendered, nil
+}
+
+func renderTree(sourceRoot string, targetRoot string, data map[string]any) (int, error) {
+	var rendered int
+	err := filepath.WalkDir(sourceRoot, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			return nil
+		}
+
+		relative, err := filepath.Rel(sourceRoot, path)
+		if err != nil {
+			return err
+		}
+		targetRelative, err := renderString("path", filepath.ToSlash(relative), data)
+		if err != nil {
+			return err
+		}
+		target, err := safeJoin(targetRoot, filepath.FromSlash(targetRelative))
+		if err != nil {
+			return err
+		}
+
+		payload, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		body, err := renderString(relative, string(payload), data)
+		if err != nil {
+			return err
+		}
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return err
+		}
+		if err := os.WriteFile(target, []byte(body), 0o644); err != nil {
+			return err
+		}
+		rendered++
+		return nil
+	})
+	if err != nil {
+		return 0, err
+	}
+	return rendered, nil
+}
+
+func renderString(name string, value string, data map[string]any) (string, error) {
+	tmpl, err := template.New(name).Option("missingkey=error").Parse(value)
+	if err != nil {
+		return "", err
+	}
+	var output strings.Builder
+	if err := tmpl.Execute(&output, data); err != nil {
+		return "", err
+	}
+	return output.String(), nil
+}
+
+func safeJoin(root string, relative string) (string, error) {
+	target := filepath.Join(root, relative)
+	cleanRoot := filepath.Clean(root)
+	cleanTarget := filepath.Clean(target)
+	if cleanTarget != cleanRoot && !strings.HasPrefix(cleanTarget, cleanRoot+string(os.PathSeparator)) {
+		return "", fmt.Errorf("template path escapes destination: %s", relative)
+	}
+	return target, nil
 }
 
 func joinSource(source string, child string) string {

--- a/internal/templatecatalog/catalog_test.go
+++ b/internal/templatecatalog/catalog_test.go
@@ -155,6 +155,93 @@ packs:
 	}
 }
 
+func TestRenderLocalTemplate(t *testing.T) {
+	registryRoot, packRoot := writeRenderablePack(t)
+	destination := t.TempDir()
+
+	result, err := SourceFetcher{}.Render(context.Background(), RenderOptions{
+		RegistrySource: registryRoot,
+		TemplateName:   "examples/renderable",
+		Destination:    destination,
+		Values: map[string]string{
+			"Name": "orders",
+		},
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if result.Template != "examples/renderable" {
+		t.Fatalf("expected examples/renderable, got %q", result.Template)
+	}
+	if result.Version != "1.2.3" {
+		t.Fatalf("expected template version 1.2.3, got %q", result.Version)
+	}
+	if result.PackVersion != "0.1.0" {
+		t.Fatalf("expected pack version 0.1.0, got %q", result.PackVersion)
+	}
+	if result.Source != "local:"+packRoot {
+		t.Fatalf("expected source local:%s, got %q", packRoot, result.Source)
+	}
+	if result.Files != 1 {
+		t.Fatalf("expected one rendered file, got %d", result.Files)
+	}
+	if result.Status != "rendered" {
+		t.Fatalf("expected rendered status, got %q", result.Status)
+	}
+
+	payload, err := os.ReadFile(filepath.Join(destination, "orders.txt"))
+	if err != nil {
+		t.Fatalf("read rendered file: %v", err)
+	}
+	if string(payload) != "hello orders\n" {
+		t.Fatalf("expected rendered file payload, got %q", payload)
+	}
+}
+
+func TestRenderRejectsPlaceholderTemplate(t *testing.T) {
+	packRoot := t.TempDir()
+	writeGatlingPack(t, packRoot)
+
+	registryRoot := t.TempDir()
+	writeFile(t, registryRoot, registryFileName, fmt.Sprintf(`apiVersion: galaxio.io/v1
+kind: TemplateRegistry
+packs:
+  - name: gatling
+    source: local:%s
+`, packRoot))
+
+	_, err := SourceFetcher{}.Render(context.Background(), RenderOptions{
+		RegistrySource: registryRoot,
+		TemplateName:   "gatling/scala-sbt",
+		Destination:    t.TempDir(),
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "coming soon") {
+		t.Fatalf("expected coming soon error, got %v", err)
+	}
+}
+
+func TestRenderRejectsEscapingPath(t *testing.T) {
+	registryRoot, _ := writeRenderablePack(t)
+
+	_, err := SourceFetcher{}.Render(context.Background(), RenderOptions{
+		RegistrySource: registryRoot,
+		TemplateName:   "examples/renderable",
+		Destination:    t.TempDir(),
+		Values: map[string]string{
+			"Name": "../escape",
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "escapes destination") {
+		t.Fatalf("expected safe path error, got %v", err)
+	}
+}
+
 func TestValidateSourceAcceptsPackWithoutTemplates(t *testing.T) {
 	root := t.TempDir()
 	writeGatlingPack(t, root)
@@ -329,6 +416,44 @@ func TestValidatePackRejectsParentPath(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error")
 	}
+}
+
+func writeRenderablePack(t *testing.T) (string, string) {
+	t.Helper()
+
+	packRoot := t.TempDir()
+	writeFile(t, packRoot, packFileName, `apiVersion: galaxio.io/v1
+kind: TemplatePack
+name: examples
+version: 0.1.0
+templates:
+  - name: renderable
+    version: 1.2.3
+    path: renderable
+`)
+	writeFile(t, filepath.Join(packRoot, "renderable"), templateFileName, `apiVersion: galaxio.io/v1
+kind: Template
+name: renderable
+engine: go-template
+inputs:
+  Name:
+    type: string
+    default: default
+files:
+  - from: files
+    to: .
+`)
+	writeFile(t, filepath.Join(packRoot, "renderable", "files"), "{{ .Name }}.txt", "hello {{ .Name }}\n")
+
+	registryRoot := t.TempDir()
+	writeFile(t, registryRoot, registryFileName, fmt.Sprintf(`apiVersion: galaxio.io/v1
+kind: TemplateRegistry
+packs:
+  - name: examples
+    source: local:%s
+`, packRoot))
+
+	return registryRoot, packRoot
 }
 
 func writeGatlingPack(t *testing.T, root string) {


### PR DESCRIPTION
## Summary

- Make `galaxio template init` render real templates instead of returning a placeholder for renderable entries.
- Load `galaxio-template.yaml`, collect input defaults, apply values from `--values`, then override with `--set Key=Value`, and render `files` with Go templates.
- Add `--destination/-d` for output directory selection.
- Add `galaxio template configure --show` and `galaxio template configure --registry ...` with persistent config at `~/.galaxio/config.yaml` or `GALAXIO_CONFIG`.
- Resolve template registry in CLI order: explicit `--registry`, config file, built-in default registry.
- Keep placeholder templates as `coming soon` when their pack entry has no `path`.
- Support local sources directly and GitHub sources through repository archive download.
- Add path traversal protection for rendered paths and archive extraction.

## Validation

- `go test ./...`
- `go vet ./...`
- `go test -race -coverprofile=coverage.out ./...`
- Local coverage threshold check: `coverage 72.7% meets required 65.0%`
- `go build -trimpath -o bin/galaxio ./cmd/galaxio`
- Manual config check: `galaxio template configure --show` and `galaxio template configure --registry github:my-org/my-template-registry`
- Local smoke: `galaxio template init gatling/scala-sbt --registry local:<registry> --destination <tmp> --values .github/template-smoke-values.yaml --set ...`
- Rendered project compile: `sbt Gatling/compile`
