### PR TITLE
feat(template): render GitHub templates from release tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Check coverage threshold
         env:
-          COVERAGE_THRESHOLD: "65.0"
+          COVERAGE_THRESHOLD: "80.0"
         run: |
           coverage=$(go tool cover -func=coverage.out | awk '/^total:/ { gsub("%", "", $3); print $3 }')
           awk -v coverage="$coverage" -v threshold="$COVERAGE_THRESHOLD" 'BEGIN {

--- a/README.md
+++ b/README.md
@@ -19,6 +19,20 @@ Install the latest version with Go:
 go install github.com/galax-io/galaxio-cli/cmd/galaxio@latest
 ```
 
+Install a tagged release binary:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/galax-io/galaxio-cli/main/scripts/install.sh | sh
+GALAXIO_VERSION=0.1.1 sh scripts/install.sh
+```
+
+The installer writes to `$HOME/.local/bin` by default. Add it to `PATH` if
+needed:
+
+```sh
+export PATH="$HOME/.local/bin:$PATH"
+```
+
 Or download a prebuilt binary from the
 [GitHub Releases](https://github.com/galax-io/galaxio-cli/releases) page.
 
@@ -52,6 +66,13 @@ galaxio completion bash
 galaxio completion zsh
 galaxio completion fish
 galaxio completion powershell
+```
+
+Example zsh install:
+
+```sh
+mkdir -p ~/.zsh/completion
+galaxio completion zsh > ~/.zsh/completion/_galaxio
 ```
 
 Update `galaxio` from GitHub Releases:

--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ galaxio update --dry-run
 galaxio update --version 0.1.1
 ```
 
+Local template examples and manifest format notes live in
+[docs/templates/README.md](docs/templates/README.md) and
+`examples/templates/`.
+
 ## Exit Codes
 
 `galaxio` keeps exit codes stable for scripts and CI:

--- a/cmd/galaxio/root_test.go
+++ b/cmd/galaxio/root_test.go
@@ -61,9 +61,41 @@ func TestTemplateCommandPrintsHelp(t *testing.T) {
 	if stderr != "" {
 		t.Fatalf("expected empty stderr, got %q", stderr)
 	}
-	for _, want := range []string{"Discover and validate", "configure", "init", "list", "validate"} {
+	for _, want := range []string{
+		"Discover, render, and validate",
+		"configure",
+		"init",
+		"list",
+		"validate",
+		"clear-cache",
+		"galaxio template init gatling/scala-sbt",
+		"--set Name=orders",
+		"--values ./template-values.yaml",
+	} {
 		if !strings.Contains(stdout, want) {
 			t.Fatalf("expected template help to contain %q, got %q", want, stdout)
+		}
+	}
+}
+
+func TestTemplateInitHelpShowsExamples(t *testing.T) {
+	code, stdout, stderr := runCLI("template", "init", "--help")
+
+	if code != exitOK {
+		t.Fatalf("expected exit code %d, got %d", exitOK, code)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	for _, want := range []string{
+		"Initialize a project from a template",
+		"galaxio template init gatling/scala-sbt",
+		"--destination ./perf",
+		"--set Name=orders",
+		"--values ./template-values.yaml",
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("expected init help to contain %q, got %q", want, stdout)
 		}
 	}
 }
@@ -329,16 +361,67 @@ func TestConfigPathUsesHomeDirectory(t *testing.T) {
 func TestWriteTemplateListCoversVersionFallbacks(t *testing.T) {
 	var stdout bytes.Buffer
 	err := writeTemplateList(&stdout, []templatecatalog.TemplateRef{
-		{Name: "examples/service", PackVersion: "0.1.0", Version: "1.2.3", Source: "local:/tmp/templates"},
-		{Name: "gatling/scala-sbt", Placeholder: true, Source: "local:/tmp/templates"},
+		{Name: "examples/service", Pack: "examples", PackVersion: "0.1.0", Version: "1.2.3", Source: "local:/tmp/templates"},
+		{Name: "gatling/scala-sbt", Pack: "gatling", PackVersion: "0.2.0", Placeholder: true, Source: "github:galax-io/templates-gatling"},
 	})
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
-	for _, want := range []string{"examples/service\t0.1.0", "gatling/scala-sbt\tcoming soon"} {
+	for _, want := range []string{
+		"Pack: examples",
+		"Pack version: 0.1.0",
+		"Source: local:/tmp/templates",
+		"service",
+		"1.2.3",
+		"Pack: gatling",
+		"Pack version: 0.2.0",
+		"Source: github:galax-io/templates-gatling",
+		"scala-sbt",
+		"coming soon",
+	} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("expected output to contain %q, got %q", want, stdout.String())
 		}
+	}
+}
+
+func TestGroupTemplatesByPackKeepsOrderAndVersions(t *testing.T) {
+	groups := groupTemplatesByPack([]templatecatalog.TemplateRef{
+		{Name: "examples/service", Pack: "examples", PackVersion: "0.1.0", Source: "local:/tmp/examples"},
+		{Name: "examples/worker", Pack: "examples", PackVersion: "0.1.0", Source: "local:/tmp/examples"},
+		{Name: "gatling/scala-sbt", Pack: "gatling", PackVersion: "0.2.0", Source: "github:galax-io/templates-gatling"},
+	})
+
+	if len(groups) != 2 {
+		t.Fatalf("expected 2 groups, got %d", len(groups))
+	}
+	if groups[0].Pack != "examples" || groups[0].PackVersion != "0.1.0" {
+		t.Fatalf("unexpected first group %#v", groups[0])
+	}
+	if len(groups[0].Templates) != 2 {
+		t.Fatalf("expected 2 templates in first group, got %d", len(groups[0].Templates))
+	}
+	if groups[1].Pack != "gatling" || groups[1].Source != "github:galax-io/templates-gatling" {
+		t.Fatalf("unexpected second group %#v", groups[1])
+	}
+}
+
+func TestTemplateDisplayNameAndVersionFallbacks(t *testing.T) {
+	if got := templateDisplayName(templatecatalog.TemplateRef{Name: "gatling/scala-sbt"}); got != "scala-sbt" {
+		t.Fatalf("expected short template name, got %q", got)
+	}
+	if got := templateDisplayName(templatecatalog.TemplateRef{Name: "standalone"}); got != "standalone" {
+		t.Fatalf("expected unchanged template name, got %q", got)
+	}
+
+	if got := templateListVersion(templatecatalog.TemplateRef{Version: "1.2.3", PackVersion: "0.1.0"}); got != "1.2.3" {
+		t.Fatalf("expected template version, got %q", got)
+	}
+	if got := templateListVersion(templatecatalog.TemplateRef{Placeholder: true}); got != "coming soon" {
+		t.Fatalf("expected coming soon placeholder, got %q", got)
+	}
+	if got := templateListVersion(templatecatalog.TemplateRef{PackVersion: "0.1.0"}); got != "0.1.0" {
+		t.Fatalf("expected pack version fallback, got %q", got)
 	}
 }
 

--- a/cmd/galaxio/root_test.go
+++ b/cmd/galaxio/root_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/galax-io/galaxio-cli/internal/buildinfo"
 	"github.com/galax-io/galaxio-cli/internal/selfupdate"
+	"github.com/galax-io/galaxio-cli/internal/templatecatalog"
 	"github.com/spf13/cobra"
 )
 
@@ -248,6 +249,103 @@ func TestUpdateResultPrintsJSONOutput(t *testing.T) {
 	}
 	if result.AssetName != "galaxio_0.2.0_darwin_arm64.tar.gz" {
 		t.Fatalf("expected asset name, got %q", result.AssetName)
+	}
+}
+
+func TestUpdateResultPrintsTextBranches(t *testing.T) {
+	tests := []struct {
+		name   string
+		result selfupdate.Result
+		want   string
+	}{
+		{
+			name: "updated",
+			result: selfupdate.Result{
+				CurrentVersion: "0.1.0",
+				TargetVersion:  "0.2.0",
+				Updated:        true,
+			},
+			want: "Updated galaxio from 0.1.0 to 0.2.0",
+		},
+		{
+			name: "dry run no update",
+			result: selfupdate.Result{
+				CurrentVersion: "0.2.0",
+				DryRun:         true,
+			},
+			want: "galaxio is already up to date (0.2.0)",
+		},
+		{
+			name: "no update",
+			result: selfupdate.Result{
+				CurrentVersion: "0.2.0",
+			},
+			want: "galaxio is already up to date (0.2.0)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var stdout bytes.Buffer
+			cmd := &cobra.Command{}
+			cmd.SetOut(&stdout)
+
+			err := printUpdateResult(cmd, tt.result, outputText)
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			if !strings.Contains(stdout.String(), tt.want) {
+				t.Fatalf("expected %q, got %q", tt.want, stdout.String())
+			}
+		})
+	}
+}
+
+func TestConfigPathUsesEnvironmentOverride(t *testing.T) {
+	t.Setenv(configEnv, "/tmp/galaxio-test-config.yaml")
+
+	path, err := configPath()
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if path != "/tmp/galaxio-test-config.yaml" {
+		t.Fatalf("expected env config path, got %q", path)
+	}
+}
+
+func TestConfigPathUsesHomeDirectory(t *testing.T) {
+	t.Setenv(configEnv, "")
+	t.Setenv("HOME", "/tmp/galaxio-home")
+
+	path, err := configPath()
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if path != "/tmp/galaxio-home/.galaxio/config.yaml" {
+		t.Fatalf("expected home config path, got %q", path)
+	}
+}
+
+func TestWriteTemplateListCoversVersionFallbacks(t *testing.T) {
+	var stdout bytes.Buffer
+	err := writeTemplateList(&stdout, []templatecatalog.TemplateRef{
+		{Name: "examples/service", PackVersion: "0.1.0", Version: "1.2.3", Source: "local:/tmp/templates"},
+		{Name: "gatling/scala-sbt", Placeholder: true, Source: "local:/tmp/templates"},
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	for _, want := range []string{"examples/service\t0.1.0", "gatling/scala-sbt\tcoming soon"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("expected output to contain %q, got %q", want, stdout.String())
+		}
+	}
+}
+
+func TestEncodeJSONRejectsUnsupportedValue(t *testing.T) {
+	_, err := encodeJSON(func() {})
+	if err == nil {
+		t.Fatal("expected json error")
 	}
 }
 

--- a/cmd/galaxio/template.go
+++ b/cmd/galaxio/template.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"text/tabwriter"
 
 	"github.com/galax-io/galaxio-cli/internal/templatecatalog"
 	"github.com/spf13/cobra"
@@ -16,7 +17,16 @@ func newTemplateCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "template",
 		Short: "Discover and validate project templates.",
-		Long:  "Discover and validate project templates from Galaxio template registries.",
+		Long:  "Discover, render, and validate project templates from Galaxio template registries.",
+		Example: strings.Join([]string{
+			"  galaxio template list",
+			"  galaxio template list --registry local:/path/to/registry",
+			"  galaxio template init gatling/scala-sbt",
+			"  galaxio template init gatling/scala-sbt --destination ./load-tests",
+			"  galaxio template init gatling/scala-sbt --set Name=orders --set Package=org.example.performance",
+			"  galaxio template init gatling/scala-sbt --values ./template-values.yaml",
+			"  galaxio template clear-cache",
+		}, "\n"),
 		Args: func(cmd *cobra.Command, args []string) error {
 			if err := cobra.NoArgs(cmd, args); err != nil {
 				return UsageError{Err: err}
@@ -30,6 +40,7 @@ func newTemplateCommand() *cobra.Command {
 
 	cmd.AddCommand(newTemplateListCommand())
 	cmd.AddCommand(newTemplateConfigureCommand())
+	cmd.AddCommand(newTemplateClearCacheCommand())
 	cmd.AddCommand(newTemplateInitCommand())
 	cmd.AddCommand(newTemplateValidateCommand())
 
@@ -136,6 +147,12 @@ func newTemplateInitCommand() *cobra.Command {
 		Use:   "init <template>",
 		Short: "Initialize a project from a template.",
 		Long:  "Initialize a project from a template resolved from a Galaxio template registry.",
+		Example: strings.Join([]string{
+			"  galaxio template init gatling/scala-sbt",
+			"  galaxio template init gatling/scala-sbt --destination ./perf",
+			"  galaxio template init gatling/scala-sbt --set Name=orders --set Package=org.example.performance",
+			"  galaxio template init gatling/scala-sbt --values ./template-values.yaml",
+		}, "\n"),
 		Args: func(cmd *cobra.Command, args []string) error {
 			if err := cobra.ExactArgs(1)(cmd, args); err != nil {
 				return UsageError{Err: err}
@@ -209,6 +226,33 @@ func newTemplateInitCommand() *cobra.Command {
 	cmd.Flags().StringVarP(&output, "output", "o", outputText, "output format: text or json")
 	cmd.Flags().StringVar(&valuesFile, "values", "", "YAML file with template values")
 	cmd.Flags().StringArrayVar(&values, "set", nil, "template value in Key=Value form")
+
+	return cmd
+}
+
+func newTemplateClearCacheCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "clear-cache",
+		Short: "Clear cached template sources.",
+		Long:  "Clear cached remote template sources downloaded for template rendering.",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if err := cobra.NoArgs(cmd, args); err != nil {
+				return UsageError{Err: err}
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			path, err := templatecatalog.ClearCache()
+			if err != nil {
+				return RuntimeError{Err: err}
+			}
+			_, err = fmt.Fprintf(cmd.OutOrStdout(), "Cleared template cache: %s\n", path)
+			if err != nil {
+				return RuntimeError{Err: err}
+			}
+			return nil
+		},
+	}
 
 	return cmd
 }
@@ -335,15 +379,34 @@ func parseTemplateValues(values []string) (map[string]string, error) {
 }
 
 func writeTemplateList(writer io.Writer, templates []templatecatalog.TemplateRef) error {
-	for _, template := range templates {
-		version := templateListVersion(template)
-		if template.Description == "" {
-			if _, err := fmt.Fprintf(writer, "%s\t%s\t%s\n", template.Name, version, template.Source); err != nil {
+	groups := groupTemplatesByPack(templates)
+	for i, group := range groups {
+		if i > 0 {
+			if _, err := fmt.Fprintln(writer); err != nil {
 				return err
 			}
-			continue
 		}
-		if _, err := fmt.Fprintf(writer, "%s\t%s\t%s\t%s\n", template.Name, version, template.Source, template.Description); err != nil {
+
+		if _, err := fmt.Fprintf(writer, "Pack: %s\n", group.Pack); err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintf(writer, "Pack version: %s\n", group.PackVersion); err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintf(writer, "Source: %s\n", group.Source); err != nil {
+			return err
+		}
+
+		tw := tabwriter.NewWriter(writer, 0, 0, 2, ' ', 0)
+		if _, err := fmt.Fprintln(tw, "Template\tVersion\tDescription"); err != nil {
+			return err
+		}
+		for _, template := range group.Templates {
+			if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\n", templateDisplayName(template), templateListVersion(template), template.Description); err != nil {
+				return err
+			}
+		}
+		if err := tw.Flush(); err != nil {
 			return err
 		}
 	}
@@ -351,7 +414,52 @@ func writeTemplateList(writer io.Writer, templates []templatecatalog.TemplateRef
 	return nil
 }
 
+type templatePackGroup struct {
+	Pack        string
+	PackVersion string
+	Source      string
+	Templates   []templatecatalog.TemplateRef
+}
+
+func groupTemplatesByPack(templates []templatecatalog.TemplateRef) []templatePackGroup {
+	groupOrder := make([]string, 0, len(templates))
+	groupByKey := make(map[string]*templatePackGroup, len(templates))
+
+	for _, template := range templates {
+		key := template.Pack + "\x00" + template.PackVersion + "\x00" + template.Source
+		group, ok := groupByKey[key]
+		if !ok {
+			group = &templatePackGroup{
+				Pack:        template.Pack,
+				PackVersion: template.PackVersion,
+				Source:      template.Source,
+			}
+			groupByKey[key] = group
+			groupOrder = append(groupOrder, key)
+		}
+		group.Templates = append(group.Templates, template)
+	}
+
+	result := make([]templatePackGroup, 0, len(groupOrder))
+	for _, key := range groupOrder {
+		result = append(result, *groupByKey[key])
+	}
+
+	return result
+}
+
+func templateDisplayName(template templatecatalog.TemplateRef) string {
+	_, shortName, ok := strings.Cut(template.Name, "/")
+	if ok && shortName != "" {
+		return shortName
+	}
+	return template.Name
+}
+
 func templateListVersion(template templatecatalog.TemplateRef) string {
+	if template.Version != "" {
+		return template.Version
+	}
 	if template.Placeholder {
 		return "coming soon"
 	}

--- a/cmd/galaxio/template.go
+++ b/cmd/galaxio/template.go
@@ -352,9 +352,6 @@ func writeTemplateList(writer io.Writer, templates []templatecatalog.TemplateRef
 }
 
 func templateListVersion(template templatecatalog.TemplateRef) string {
-	if template.Version != "" {
-		return template.Version
-	}
 	if template.Placeholder {
 		return "coming soon"
 	}

--- a/cmd/galaxio/template_command_test.go
+++ b/cmd/galaxio/template_command_test.go
@@ -19,13 +19,17 @@ func TestTemplateListWithLocalRegistry(t *testing.T) {
 	if stderr != "" {
 		t.Fatalf("expected empty stderr, got %q", stderr)
 	}
-	for _, want := range []string{"gatling/scala-sbt", "coming soon", "local:" + packRoot, "Gatling Scala project with sbt"} {
+	for _, want := range []string{
+		"Pack: gatling",
+		"Pack version: 0.1.0",
+		"Source: local:" + packRoot,
+		"scala-sbt",
+		"coming soon",
+		"Gatling Scala project with sbt",
+	} {
 		if !strings.Contains(stdout, want) {
 			t.Fatalf("expected output to contain %q, got %q", want, stdout)
 		}
-	}
-	if strings.Contains(stdout, "\t0.1.0\t") {
-		t.Fatalf("expected placeholder template list to omit pack version, got %q", stdout)
 	}
 }
 
@@ -103,7 +107,7 @@ func TestTemplateListUsesConfiguredRegistry(t *testing.T) {
 	if stderr != "" {
 		t.Fatalf("expected empty list stderr, got %q", stderr)
 	}
-	for _, want := range []string{"gatling/scala-sbt", "local:" + packRoot} {
+	for _, want := range []string{"Pack: gatling", "Pack version: 0.1.0", "Source: local:" + packRoot, "scala-sbt"} {
 		if !strings.Contains(stdout, want) {
 			t.Fatalf("expected configured registry output to contain %q, got %q", want, stdout)
 		}
@@ -126,6 +130,34 @@ func TestTemplateConfigureShowsDefaultRegistry(t *testing.T) {
 		if !strings.Contains(stdout, want) {
 			t.Fatalf("expected configure output to contain %q, got %q", want, stdout)
 		}
+	}
+}
+
+func TestTemplateClearCacheRemovesCachedFiles(t *testing.T) {
+	cacheRoot := t.TempDir()
+	t.Setenv("GALAXIO_CACHE_DIR", cacheRoot)
+
+	cachePath := filepath.Join(cacheRoot, "templates", "sources", "cached", "entry.txt")
+	if err := os.MkdirAll(filepath.Dir(cachePath), 0o755); err != nil {
+		t.Fatalf("mkdir cache dir: %v", err)
+	}
+	if err := os.WriteFile(cachePath, []byte("cached"), 0o644); err != nil {
+		t.Fatalf("write cache file: %v", err)
+	}
+
+	code, stdout, stderr := runCLI("template", "clear-cache")
+
+	if code != exitOK {
+		t.Fatalf("expected exit code %d, got %d, stderr %q", exitOK, code, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, "Cleared template cache: ") {
+		t.Fatalf("expected clear cache output, got %q", stdout)
+	}
+	if _, err := os.Stat(filepath.Join(cacheRoot, "templates")); !os.IsNotExist(err) {
+		t.Fatalf("expected template cache removed, got %v", err)
 	}
 }
 

--- a/docs/templates/README.md
+++ b/docs/templates/README.md
@@ -2,9 +2,8 @@
 
 Galaxio registries describe where the CLI can discover template packs.
 
-This first step only defines the default registry contract. Template pack and
-template rendering formats will be added separately. Commands currently operate
-at discovery and validation level, not rendering level.
+The CLI now supports discovery, validation, and rendering for local sources and
+GitHub-backed template packs.
 
 ## Default Registry
 
@@ -20,8 +19,10 @@ override the default registry with another source.
 ## Concepts
 
 - **Registry**: an index of template packs available to the CLI.
-- **Pack**: a repository that groups related templates. Pack structure is not
-  defined in this step.
+- **Pack**: a repository or local directory that groups related templates and
+  declares the pack version used for GitHub release resolution.
+- **Template**: one renderable project skeleton with declared inputs and file
+  mappings.
 
 ## Registry
 
@@ -49,6 +50,70 @@ packs:
 `template list` reads the latest registry and pack manifests. `template init`
 uses the listed pack version as the immutable GitHub release tag.
 
+## Local Examples
+
+The repository includes a complete local example under
+`examples/templates`:
+
+```text
+examples/templates/
+  registry/galaxio-registry.yaml
+  packs/basic/galaxio-pack.yaml
+  packs/basic/service/galaxio-template.yaml
+  packs/basic/service/files/...
+```
+
+Use it as a starting point for your own local repositories:
+
+```sh
+galaxio template list --registry local:examples/templates/registry
+galaxio template validate local:examples/templates/packs/basic
+galaxio template init examples/service --registry local:examples/templates/registry --destination ./tmp/example-service
+```
+
+The minimal required manifests are:
+
+Registry:
+
+```yaml
+apiVersion: galaxio.io/v1
+kind: TemplateRegistry
+packs:
+  - name: examples
+    source: local:examples/templates/packs/basic
+```
+
+Pack:
+
+```yaml
+apiVersion: galaxio.io/v1
+kind: TemplatePack
+name: examples
+version: 0.1.0
+templates:
+  - name: service
+    version: 0.1.0
+    path: service
+```
+
+Template:
+
+```yaml
+apiVersion: galaxio.io/v1
+kind: Template
+name: service
+engine: go-template
+inputs:
+  Name:
+    type: string
+    default: myservice
+files:
+  - from: files
+    to: .
+```
+
+`local:` sources are resolved from the current working directory.
+
 ## Planned CLI Flow
 
 ```sh
@@ -60,7 +125,7 @@ galaxio template validate github:galax-io/templates-gatling
 galaxio doctor
 ```
 
-Later steps will add persistent configuration and rendering:
+Persistent configuration is also supported:
 
 ```sh
 galaxio template configure --show

--- a/docs/templates/README.md
+++ b/docs/templates/README.md
@@ -36,6 +36,19 @@ packs:
     description: Gatling performance testing templates
 ```
 
+For GitHub packs, `template init` renders from the release tag that matches the
+pack version. A listed pack version `0.3.0` resolves to repository tag `v0.3.0`.
+The registry still points at the repository, not at a pinned tag:
+
+```yaml
+packs:
+  - name: gatling
+    source: github:galax-io/templates-gatling
+```
+
+`template list` reads the latest registry and pack manifests. `template init`
+uses the listed pack version as the immutable GitHub release tag.
+
 ## Planned CLI Flow
 
 ```sh

--- a/examples/templates/packs/basic/galaxio-pack.yaml
+++ b/examples/templates/packs/basic/galaxio-pack.yaml
@@ -1,0 +1,10 @@
+apiVersion: galaxio.io/v1
+kind: TemplatePack
+name: examples
+version: 0.1.0
+description: Example local template pack for Galaxio CLI.
+templates:
+  - name: service
+    version: 0.1.0
+    path: service
+    description: Minimal service skeleton rendered from local files

--- a/examples/templates/packs/basic/service/files/README.md
+++ b/examples/templates/packs/basic/service/files/README.md
@@ -1,0 +1,12 @@
+# {{ .Name }}
+
+Owned by: {{ .Owner }}
+
+## Module
+
+`{{ .Module }}`
+
+## Next Steps
+
+- Replace this example README with project-specific details.
+- Add source files and CI configuration.

--- a/examples/templates/packs/basic/service/files/go.mod
+++ b/examples/templates/packs/basic/service/files/go.mod
@@ -1,0 +1,3 @@
+module {{ .Module }}
+
+go 1.24.0

--- a/examples/templates/packs/basic/service/galaxio-template.yaml
+++ b/examples/templates/packs/basic/service/galaxio-template.yaml
@@ -1,0 +1,25 @@
+apiVersion: galaxio.io/v1
+kind: Template
+name: service
+displayName: Example Service
+description: Minimal local template example.
+engine: go-template
+tags:
+  - example
+  - local
+inputs:
+  Name:
+    type: string
+    default: myservice
+    description: Project directory and visible service name.
+  Module:
+    type: string
+    default: github.com/acme/myservice
+    description: Go module or repository identifier.
+  Owner:
+    type: string
+    default: Platform Team
+    description: Team or owner label shown in the README.
+files:
+  - from: files
+    to: .

--- a/examples/templates/registry/galaxio-registry.yaml
+++ b/examples/templates/registry/galaxio-registry.yaml
@@ -1,6 +1,6 @@
 apiVersion: galaxio.io/v1
 kind: TemplateRegistry
 packs:
-  - name: gatling
-    source: github:galax-io/templates-gatling
-    description: Gatling performance testing templates
+  - name: examples
+    source: local:examples/templates/packs/basic
+    description: Local example templates for custom packs

--- a/internal/selfupdate/selfupdate_test.go
+++ b/internal/selfupdate/selfupdate_test.go
@@ -279,6 +279,31 @@ func TestExtractBinaryFromZip(t *testing.T) {
 	}
 }
 
+func TestArchiveAndExecutableNames(t *testing.T) {
+	if got := archiveName("v1.2.3", "windows", "amd64"); got != "galaxio_1.2.3_windows_amd64.zip" {
+		t.Fatalf("unexpected windows archive name %q", got)
+	}
+	if got := archiveName("1.2.3", "linux", "arm64"); got != "galaxio_1.2.3_linux_arm64.tar.gz" {
+		t.Fatalf("unexpected linux archive name %q", got)
+	}
+	if got := executableName("windows"); got != "galaxio.exe" {
+		t.Fatalf("unexpected windows executable name %q", got)
+	}
+	if got := executableName("darwin"); got != "galaxio" {
+		t.Fatalf("unexpected darwin executable name %q", got)
+	}
+}
+
+func TestFindAssetRejectsMissingAsset(t *testing.T) {
+	_, err := findAsset([]asset{{Name: "checksums.txt"}}, "galaxio_1.2.3_linux_amd64.tar.gz")
+	if err == nil {
+		t.Fatal("expected missing asset error")
+	}
+	if !strings.Contains(err.Error(), "release asset") {
+		t.Fatalf("unexpected error %v", err)
+	}
+}
+
 func serverURL(r *http.Request) string {
 	return "http://" + r.Host
 }

--- a/internal/templatecatalog/catalog.go
+++ b/internal/templatecatalog/catalog.go
@@ -242,12 +242,13 @@ func (f SourceFetcher) Render(ctx context.Context, opts RenderOptions) (RenderRe
 		return RenderResult{}, fmt.Errorf("template %q is coming soon", ref.Name)
 	}
 
-	manifest, err := f.LoadTemplate(ctx, ref.Source, ref.Path)
+	renderSource := ref.renderSource()
+	manifest, err := f.LoadTemplate(ctx, renderSource, ref.Path)
 	if err != nil {
 		return RenderResult{}, err
 	}
 
-	sourceRoot, cleanup, err := f.materializeSource(ctx, ref.Source)
+	sourceRoot, cleanup, err := f.materializeSource(ctx, renderSource)
 	if err != nil {
 		return RenderResult{}, err
 	}
@@ -443,11 +444,11 @@ func (f SourceFetcher) materializeSource(ctx context.Context, source string) (st
 }
 
 func (f SourceFetcher) materializeGitHubSource(ctx context.Context, repo string) (string, func(), error) {
-	owner, name, subpath, err := parseGitHubSource(repo)
+	ref, err := parseGitHubSource(repo, "main")
 	if err != nil {
 		return "", nil, err
 	}
-	payload, err := f.readURL(ctx, fmt.Sprintf("https://codeload.github.com/%s/%s/zip/refs/heads/main", owner, name))
+	payload, err := f.readURL(ctx, ref.archiveURL())
 	if err != nil {
 		return "", nil, err
 	}
@@ -480,7 +481,7 @@ func (f SourceFetcher) materializeGitHubSource(ctx context.Context, repo string)
 		return "", nil, fmt.Errorf("unexpected GitHub archive layout for %q", repo)
 	}
 
-	return filepath.Join(tempDir, entries[0].Name(), filepath.FromSlash(subpath)), cleanup, nil
+	return filepath.Join(tempDir, entries[0].Name(), filepath.FromSlash(ref.Subpath)), cleanup, nil
 }
 
 func readLocalManifest(root string, manifest string) ([]byte, error) {
@@ -501,29 +502,70 @@ func readLocalManifest(root string, manifest string) ([]byte, error) {
 }
 
 func githubRawURL(repo string, manifest string) string {
-	parts := strings.Split(strings.Trim(repo, "/"), "/")
-	if len(parts) < 2 {
+	ref, err := parseGitHubSource(repo, "main")
+	if err != nil {
 		return "https://raw.githubusercontent.com/" + strings.Trim(repo, "/") + "/main/" + manifest
 	}
 
 	path := ""
-	if len(parts) > 2 {
-		path = strings.Join(parts[2:], "/") + "/"
+	if ref.Subpath != "" {
+		path = strings.Trim(ref.Subpath, "/") + "/"
 	}
 
-	return "https://raw.githubusercontent.com/" + parts[0] + "/" + parts[1] + "/main/" + path + manifest
+	return fmt.Sprintf("https://raw.githubusercontent.com/%s/%s/%s/%s%s", ref.Owner, ref.Repo, ref.Ref, path, manifest)
 }
 
-func parseGitHubSource(repo string) (string, string, string, error) {
+type githubSource struct {
+	Owner   string
+	Repo    string
+	Ref     string
+	Subpath string
+}
+
+func parseGitHubSource(repo string, fallbackRef string) (githubSource, error) {
+	repo, ref, hasRef := strings.Cut(repo, "#")
+	if !hasRef || ref == "" {
+		ref = fallbackRef
+	}
+
 	parts := strings.Split(strings.Trim(repo, "/"), "/")
 	if len(parts) < 2 {
-		return "", "", "", fmt.Errorf("github source must be owner/repo, got %q", repo)
+		return githubSource{}, fmt.Errorf("github source must be owner/repo, got %q", repo)
 	}
+	if parts[1] == "" {
+		return githubSource{}, fmt.Errorf("github source must include repository name, got %q", repo)
+	}
+
 	subpath := ""
 	if len(parts) > 2 {
 		subpath = strings.Join(parts[2:], "/")
 	}
-	return parts[0], parts[1], subpath, nil
+	return githubSource{
+		Owner:   parts[0],
+		Repo:    parts[1],
+		Ref:     ref,
+		Subpath: subpath,
+	}, nil
+}
+
+func (s githubSource) archiveURL() string {
+	refPath := s.Ref
+	if s.Ref == "main" || s.Ref == "master" {
+		refPath = "refs/heads/" + s.Ref
+	} else if strings.HasPrefix(s.Ref, "v") {
+		refPath = "refs/tags/" + s.Ref
+	}
+	return fmt.Sprintf("https://codeload.github.com/%s/%s/zip/%s", s.Owner, s.Repo, refPath)
+}
+
+func (r TemplateRef) renderSource() string {
+	if !strings.HasPrefix(r.Source, "github:") {
+		return r.Source
+	}
+	if r.PackVersion == "" {
+		return r.Source
+	}
+	return r.Source + "#v" + strings.TrimPrefix(r.PackVersion, "v")
 }
 
 func extractZip(reader *zip.Reader, destination string) error {

--- a/internal/templatecatalog/catalog.go
+++ b/internal/templatecatalog/catalog.go
@@ -6,6 +6,8 @@ import (
 	"archive/zip"
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -23,6 +25,7 @@ const (
 	registryFileName      = "galaxio-registry.yaml"
 	packFileName          = "galaxio-pack.yaml"
 	templateFileName      = "galaxio-template.yaml"
+	cacheEnv              = "GALAXIO_CACHE_DIR"
 )
 
 // ErrTemplateNotFound is returned when a registry does not contain a requested
@@ -448,40 +451,62 @@ func (f SourceFetcher) materializeGitHubSource(ctx context.Context, repo string)
 	if err != nil {
 		return "", nil, err
 	}
+	cacheDir, err := templateCacheArchiveDir(repo)
+	if err != nil {
+		return "", nil, err
+	}
+	markerPath := filepath.Join(cacheDir, ".ready")
+	if ready, err := cacheReady(cacheDir, markerPath); err == nil && ready {
+		return filepath.Join(cacheDir, filepath.FromSlash(ref.Subpath)), func() {}, nil
+	}
+
 	payload, err := f.readURL(ctx, ref.archiveURL())
 	if err != nil {
 		return "", nil, err
 	}
 
-	tempDir, err := os.MkdirTemp("", "galaxio-template-*")
-	if err != nil {
-		return "", nil, err
-	}
-	cleanup := func() {
-		_ = os.RemoveAll(tempDir)
-	}
-
 	reader, err := zip.NewReader(bytes.NewReader(payload), int64(len(payload)))
 	if err != nil {
-		cleanup()
 		return "", nil, err
 	}
+
+	tempDir, err := os.MkdirTemp(filepath.Dir(cacheDir), "template-extract-*")
+	if err != nil {
+		return "", nil, err
+	}
+	cleanupTemp := func() {
+		_ = os.RemoveAll(tempDir)
+	}
 	if err := extractZip(reader, tempDir); err != nil {
-		cleanup()
+		cleanupTemp()
 		return "", nil, err
 	}
 
 	entries, err := os.ReadDir(tempDir)
 	if err != nil {
-		cleanup()
+		cleanupTemp()
 		return "", nil, err
 	}
 	if len(entries) != 1 || !entries[0].IsDir() {
-		cleanup()
+		cleanupTemp()
 		return "", nil, fmt.Errorf("unexpected GitHub archive layout for %q", repo)
 	}
 
-	return filepath.Join(tempDir, entries[0].Name(), filepath.FromSlash(ref.Subpath)), cleanup, nil
+	if err := os.RemoveAll(cacheDir); err != nil && !errors.Is(err, os.ErrNotExist) {
+		cleanupTemp()
+		return "", nil, err
+	}
+	if err := os.Rename(filepath.Join(tempDir, entries[0].Name()), cacheDir); err != nil {
+		cleanupTemp()
+		return "", nil, err
+	}
+	if err := os.WriteFile(markerPath, []byte("ok\n"), 0o644); err != nil {
+		_ = os.RemoveAll(cacheDir)
+		return "", nil, err
+	}
+	cleanupTemp()
+
+	return filepath.Join(cacheDir, filepath.FromSlash(ref.Subpath)), func() {}, nil
 }
 
 func readLocalManifest(root string, manifest string) ([]byte, error) {
@@ -566,6 +591,55 @@ func (r TemplateRef) renderSource() string {
 		return r.Source
 	}
 	return r.Source + "#v" + strings.TrimPrefix(r.PackVersion, "v")
+}
+
+func CacheDir() (string, error) {
+	if path := os.Getenv(cacheEnv); path != "" {
+		return filepath.Join(path, "templates"), nil
+	}
+	root, err := os.UserCacheDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(root, "galaxio", "templates"), nil
+}
+
+func ClearCache() (string, error) {
+	dir, err := CacheDir()
+	if err != nil {
+		return "", err
+	}
+	if err := os.RemoveAll(dir); err != nil {
+		return "", err
+	}
+	return dir, nil
+}
+
+func templateCacheArchiveDir(source string) (string, error) {
+	root, err := CacheDir()
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256([]byte(source))
+	return filepath.Join(root, "sources", hex.EncodeToString(sum[:])), os.MkdirAll(filepath.Join(root, "sources"), 0o755)
+}
+
+func cacheReady(dir string, markerPath string) (bool, error) {
+	info, err := os.Stat(markerPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, err
+	}
+	if !info.Mode().IsRegular() {
+		return false, nil
+	}
+	entryInfo, err := os.Stat(dir)
+	if err != nil {
+		return false, err
+	}
+	return entryInfo.IsDir(), nil
 }
 
 func extractZip(reader *zip.Reader, destination string) error {

--- a/internal/templatecatalog/catalog_test.go
+++ b/internal/templatecatalog/catalog_test.go
@@ -1,6 +1,8 @@
 package templatecatalog
 
 import (
+	"archive/zip"
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -339,6 +341,116 @@ files:
 	}
 }
 
+func TestRenderFromGitHubSourceUsesPackVersionTag(t *testing.T) {
+	archive := zipSource(t, "templates-gatling-0.3.0/service/files/{{ .Name }}.txt", "hello {{ .Name }}\n")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/galax-io/templates-gatling/main/galaxio-pack.yaml":
+			_, _ = w.Write([]byte(`apiVersion: galaxio.io/v1
+kind: TemplatePack
+name: examples
+version: 0.3.0
+templates:
+  - name: service
+    version: service-local-version
+    path: service
+`))
+		case "/galax-io/templates-gatling/v0.3.0/service/galaxio-template.yaml":
+			_, _ = w.Write([]byte(`apiVersion: galaxio.io/v1
+kind: Template
+name: service
+engine: go-template
+inputs:
+  Name:
+    type: string
+    default: default
+files:
+  - from: files
+    to: .
+`))
+		case "/galax-io/templates-gatling/zip/refs/tags/v0.3.0":
+			_, _ = w.Write(archive)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	registryRoot := t.TempDir()
+	writeFile(t, registryRoot, registryFileName, `apiVersion: galaxio.io/v1
+kind: TemplateRegistry
+packs:
+  - name: examples
+    source: github:galax-io/templates-gatling
+`)
+
+	destination := t.TempDir()
+	result, err := (SourceFetcher{HTTPClient: rewriteClient(t, server.URL)}).Render(context.Background(), RenderOptions{
+		RegistrySource: registryRoot,
+		TemplateName:   "examples/service",
+		Destination:    destination,
+		Values:         map[string]string{"Name": "orders"},
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if result.PackVersion != "0.3.0" || result.Files != 1 {
+		t.Fatalf("unexpected render result %#v", result)
+	}
+
+	payload, err := os.ReadFile(filepath.Join(destination, "orders.txt"))
+	if err != nil {
+		t.Fatalf("read rendered file: %v", err)
+	}
+	if string(payload) != "hello orders\n" {
+		t.Fatalf("unexpected rendered payload %q", payload)
+	}
+}
+
+func TestMaterializeSourceRejectsURLSources(t *testing.T) {
+	_, _, err := SourceFetcher{}.materializeSource(context.Background(), "https://example.com/templates")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "URL sources is not supported") {
+		t.Fatalf("unexpected error %v", err)
+	}
+}
+
+func TestRenderRejectsEscapingTemplatePath(t *testing.T) {
+	registryRoot, _ := writeRenderablePack(t)
+	_, err := SourceFetcher{}.Render(context.Background(), RenderOptions{
+		RegistrySource: registryRoot,
+		TemplateName:   "examples/renderable",
+		Destination:    t.TempDir(),
+		Values:         map[string]string{"Name": "../escape"},
+	})
+	if err == nil {
+		t.Fatal("expected escaping path error")
+	}
+	if !strings.Contains(err.Error(), "template path escapes destination") {
+		t.Fatalf("unexpected error %v", err)
+	}
+}
+
+func TestParseGitHubSourceRejectsMissingRepoName(t *testing.T) {
+	_, err := parseGitHubSource("galax-io/", "main")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "owner/repo") {
+		t.Fatalf("expected owner/repo error, got %v", err)
+	}
+}
+
+func TestSourceErrorUnwrap(t *testing.T) {
+	cause := errors.New("boom")
+	err := SourceError{Source: "local:/tmp/missing", What: "read", Err: cause}
+	if !errors.Is(err, cause) {
+		t.Fatalf("expected source error to unwrap cause")
+	}
+}
+
 func TestValidateRegistryRejectsMissingPacks(t *testing.T) {
 	err := ValidateRegistry(Registry{
 		APIVersion: "galaxio.io/v1",
@@ -347,6 +459,122 @@ func TestValidateRegistryRejectsMissingPacks(t *testing.T) {
 
 	if err == nil {
 		t.Fatal("expected error")
+	}
+}
+
+func TestValidateRegistryRejectsMissingPackNameAndSource(t *testing.T) {
+	tests := []struct {
+		name     string
+		registry Registry
+		want     string
+	}{
+		{
+			name: "missing name",
+			registry: Registry{
+				APIVersion: "galaxio.io/v1",
+				Kind:       "TemplateRegistry",
+				Packs:      []RegistryPack{{Source: "github:galax-io/templates-gatling"}},
+			},
+			want: "registry pack name is required",
+		},
+		{
+			name: "missing source",
+			registry: Registry{
+				APIVersion: "galaxio.io/v1",
+				Kind:       "TemplateRegistry",
+				Packs:      []RegistryPack{{Name: "gatling"}},
+			},
+			want: `registry pack "gatling" source is required`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateRegistry(tt.registry)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("expected %q error, got %v", tt.want, err)
+			}
+		})
+	}
+}
+
+func TestValidatePackRejectsInvalidTemplateEntries(t *testing.T) {
+	tests := []struct {
+		name string
+		pack Pack
+		want string
+	}{
+		{
+			name: "missing template name",
+			pack: Pack{
+				APIVersion: "galaxio.io/v1",
+				Kind:       "TemplatePack",
+				Name:       "gatling",
+				Version:    "0.1.0",
+				Templates:  []PackTemplate{{Path: "scala-sbt"}},
+			},
+			want: "template name is required",
+		},
+		{
+			name: "template path escapes",
+			pack: Pack{
+				APIVersion: "galaxio.io/v1",
+				Kind:       "TemplatePack",
+				Name:       "gatling",
+				Version:    "0.1.0",
+				Templates:  []PackTemplate{{Name: "scala-sbt", Path: "../scala-sbt"}},
+			},
+			want: `template "scala-sbt" path must not contain '..'`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidatePack(tt.pack)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("expected %q error, got %v", tt.want, err)
+			}
+		})
+	}
+}
+
+func TestValidateTemplateRejectsMissingInputsAndFiles(t *testing.T) {
+	tests := []struct {
+		name     string
+		template Template
+		want     string
+	}{
+		{
+			name: "missing inputs",
+			template: Template{
+				APIVersion: "galaxio.io/v1",
+				Kind:       "Template",
+				Name:       "scala-sbt",
+				Engine:     "go-template",
+				Files:      []TemplateFile{{From: "files", To: "."}},
+			},
+			want: "template inputs are required",
+		},
+		{
+			name: "missing files",
+			template: Template{
+				APIVersion: "galaxio.io/v1",
+				Kind:       "Template",
+				Name:       "scala-sbt",
+				Engine:     "go-template",
+				Inputs:     map[string]TemplateInput{"Name": {Type: "string"}},
+			},
+			want: "template files are required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateTemplate(tt.template)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("expected %q error, got %v", tt.want, err)
+			}
+		})
 	}
 }
 
@@ -494,6 +722,25 @@ func rewriteClient(t *testing.T, baseURL string) *http.Client {
 	})
 
 	return &http.Client{Transport: transport}
+}
+
+func zipSource(t *testing.T, name string, body string) []byte {
+	t.Helper()
+
+	var buffer bytes.Buffer
+	writer := zip.NewWriter(&buffer)
+	file, err := writer.Create(name)
+	if err != nil {
+		t.Fatalf("create zip entry: %v", err)
+	}
+	if _, err := file.Write([]byte(body)); err != nil {
+		t.Fatalf("write zip entry: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close zip: %v", err)
+	}
+
+	return buffer.Bytes()
 }
 
 type roundTripFunc func(*http.Request) (*http.Response, error)

--- a/internal/templatecatalog/catalog_test.go
+++ b/internal/templatecatalog/catalog_test.go
@@ -407,6 +407,154 @@ packs:
 	}
 }
 
+func TestRenderFromGitHubSourceUsesCacheOnSecondRun(t *testing.T) {
+	t.Setenv(cacheEnv, t.TempDir())
+
+	archive := zipSource(t, "templates-gatling-0.3.0/service/files/{{ .Name }}.txt", "hello {{ .Name }}\n")
+	var archiveRequests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/galax-io/templates-gatling/main/galaxio-pack.yaml":
+			_, _ = w.Write([]byte(`apiVersion: galaxio.io/v1
+kind: TemplatePack
+name: examples
+version: 0.3.0
+templates:
+  - name: service
+    version: service-local-version
+    path: service
+`))
+		case "/galax-io/templates-gatling/v0.3.0/service/galaxio-template.yaml":
+			_, _ = w.Write([]byte(`apiVersion: galaxio.io/v1
+kind: Template
+name: service
+engine: go-template
+inputs:
+  Name:
+    type: string
+    default: default
+files:
+  - from: files
+    to: .
+`))
+		case "/galax-io/templates-gatling/zip/refs/tags/v0.3.0":
+			archiveRequests++
+			_, _ = w.Write(archive)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	registryRoot := t.TempDir()
+	writeFile(t, registryRoot, registryFileName, `apiVersion: galaxio.io/v1
+kind: TemplateRegistry
+packs:
+  - name: examples
+    source: github:galax-io/templates-gatling
+`)
+
+	fetcher := SourceFetcher{HTTPClient: rewriteClient(t, server.URL)}
+	for i := 0; i < 2; i++ {
+		_, err := fetcher.Render(context.Background(), RenderOptions{
+			RegistrySource: registryRoot,
+			TemplateName:   "examples/service",
+			Destination:    t.TempDir(),
+			Values:         map[string]string{"Name": "orders"},
+		})
+		if err != nil {
+			t.Fatalf("render %d failed: %v", i+1, err)
+		}
+	}
+
+	if archiveRequests != 1 {
+		t.Fatalf("expected one archive request, got %d", archiveRequests)
+	}
+}
+
+func TestClearCacheRemovesTemplateCacheDirectory(t *testing.T) {
+	cacheRoot := t.TempDir()
+	t.Setenv(cacheEnv, cacheRoot)
+
+	dir, err := CacheDir()
+	if err != nil {
+		t.Fatalf("cache dir: %v", err)
+	}
+	path := filepath.Join(dir, "sources", "cached", "file.txt")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("hello"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	cleared, err := ClearCache()
+	if err != nil {
+		t.Fatalf("clear cache: %v", err)
+	}
+	if cleared != dir {
+		t.Fatalf("expected cleared path %q, got %q", dir, cleared)
+	}
+	if _, err := os.Stat(dir); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected cache dir removed, got %v", err)
+	}
+}
+
+func TestClearCacheReturnsPathWhenDirectoryDoesNotExist(t *testing.T) {
+	cacheRoot := t.TempDir()
+	t.Setenv(cacheEnv, cacheRoot)
+
+	dir, err := CacheDir()
+	if err != nil {
+		t.Fatalf("cache dir: %v", err)
+	}
+	cleared, err := ClearCache()
+	if err != nil {
+		t.Fatalf("clear cache: %v", err)
+	}
+	if cleared != dir {
+		t.Fatalf("expected cleared path %q, got %q", dir, cleared)
+	}
+}
+
+func TestCacheReadyHandlesMissingMarkerAndDirectory(t *testing.T) {
+	root := t.TempDir()
+
+	ready, err := cacheReady(filepath.Join(root, "cache"), filepath.Join(root, "cache", ".ready"))
+	if err != nil {
+		t.Fatalf("cache ready returned error: %v", err)
+	}
+	if ready {
+		t.Fatal("expected cache to be not ready")
+	}
+}
+
+func TestCacheReadyRejectsNonRegularMarker(t *testing.T) {
+	root := t.TempDir()
+	cacheDir := filepath.Join(root, "cache")
+	marker := filepath.Join(cacheDir, ".ready")
+	if err := os.MkdirAll(marker, 0o755); err != nil {
+		t.Fatalf("mkdir marker dir: %v", err)
+	}
+
+	ready, err := cacheReady(cacheDir, marker)
+	if err != nil {
+		t.Fatalf("cache ready returned error: %v", err)
+	}
+	if ready {
+		t.Fatal("expected cache to be not ready for non-regular marker")
+	}
+}
+
+func TestSourceOrDefaultUsesFallback(t *testing.T) {
+	if got := sourceOrDefault(""); got != DefaultRegistrySource {
+		t.Fatalf("expected default source, got %q", got)
+	}
+	if got := sourceOrDefault("local:/tmp/registry"); got != "local:/tmp/registry" {
+		t.Fatalf("expected explicit source, got %q", got)
+	}
+}
+
 func TestMaterializeSourceRejectsURLSources(t *testing.T) {
 	_, _, err := SourceFetcher{}.materializeSource(context.Background(), "https://example.com/templates")
 	if err == nil {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env sh
+set -eu
+
+repo="${GALAXIO_REPO:-galax-io/galaxio-cli}"
+version="${GALAXIO_VERSION:-latest}"
+bin_dir="${GALAXIO_BIN_DIR:-$HOME/.local/bin}"
+tmp_dir="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
+
+need() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "missing required command: $1" >&2
+    exit 1
+  }
+}
+
+need curl
+need shasum
+need tar
+need unzip
+
+os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+arch="$(uname -m)"
+case "$arch" in
+  x86_64 | amd64) arch="amd64" ;;
+  arm64 | aarch64) arch="arm64" ;;
+  *) echo "unsupported arch: $arch" >&2; exit 1 ;;
+esac
+
+api="https://api.github.com/repos/$repo/releases/latest"
+if [ "$version" != "latest" ]; then
+  version="${version#v}"
+  api="https://api.github.com/repos/$repo/releases/tags/v$version"
+fi
+
+release="$tmp_dir/release.json"
+curl -fsSL -H "Accept: application/vnd.github+json" "$api" -o "$release"
+
+tag="$(sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$release" | head -1)"
+version="${tag#v}"
+asset="galaxio_${version}_${os}_${arch}.tar.gz"
+[ "$os" = "windows" ] && asset="galaxio_${version}_${os}_${arch}.zip"
+
+asset_url="$(sed -n "s/.*\"browser_download_url\"[[:space:]]*:[[:space:]]*\"\\([^\"]*${asset}\\)\".*/\\1/p" "$release" | head -1)"
+checksums_url="$(sed -n 's/.*"browser_download_url"[[:space:]]*:[[:space:]]*"\([^"]*checksums.txt\)".*/\1/p' "$release" | head -1)"
+
+if [ -z "$asset_url" ] || [ -z "$checksums_url" ]; then
+  echo "release asset not found for $os/$arch in $repo $tag" >&2
+  exit 1
+fi
+
+curl -fsSL "$asset_url" -o "$tmp_dir/$asset"
+curl -fsSL "$checksums_url" -o "$tmp_dir/checksums.txt"
+
+(cd "$tmp_dir" && grep "  $asset\$" checksums.txt | shasum -a 256 -c -)
+
+mkdir -p "$bin_dir"
+case "$asset" in
+  *.zip) unzip -p "$tmp_dir/$asset" galaxio.exe > "$bin_dir/galaxio.exe"; chmod +x "$bin_dir/galaxio.exe" ;;
+  *) tar -xzf "$tmp_dir/$asset" -C "$tmp_dir" galaxio; install -m 0755 "$tmp_dir/galaxio" "$bin_dir/galaxio" ;;
+esac
+
+echo "installed galaxio $version to $bin_dir"
+echo "ensure PATH contains: $bin_dir"
+echo "completion:"
+echo "  zsh:  galaxio completion zsh > \"\${fpath[1]}/_galaxio\""
+echo "  bash: galaxio completion bash > /usr/local/etc/bash_completion.d/galaxio"


### PR DESCRIPTION
## Summary
- keep registry sources as repository refs like `github:galax-io/templates-gatling`
- make `template init` render GitHub packs from release tag `v<pack.version>`
- make `template list` display pack version only; per-template versions no longer drive output or download
- add release installer script and completion/PATH docs
- raise CI coverage rule to 80%
- add tests; total coverage 80.3%

## Test
- `go test -race -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out | tail -1`