### PR TITLE
feat(template): support conditional file mappings

### DIFF
--- a/docs/templates/README.md
+++ b/docs/templates/README.md
@@ -110,7 +110,15 @@ inputs:
 files:
   - from: files
     to: .
+  - from: files/plugins/kafka
+    to: plugins
+    if: '{{ .KafkaEnabled }}'
 ```
+
+`files[].if` is optional. When present, the mapping is rendered only if the
+expression evaluates to a truthy value such as `true`, `1`, `yes`, or `on`.
+The condition is evaluated against the same data used by the rest of the
+template, including manifest defaults and `--values` / `--set` overrides.
 
 `local:` sources are resolved from the current working directory.
 

--- a/internal/templatecatalog/catalog.go
+++ b/internal/templatecatalog/catalog.go
@@ -89,6 +89,7 @@ type Template struct {
 type TemplateFile struct {
 	From string `yaml:"from"`
 	To   string `yaml:"to"`
+	If   string `yaml:"if"`
 }
 
 // TemplateRef is a resolved template available to users.
@@ -696,6 +697,13 @@ func templateData(manifest Template, overrides map[string]string) map[string]any
 func renderTemplateFiles(templateRoot string, destination string, manifest Template, data map[string]any) (int, error) {
 	var rendered int
 	for _, mapping := range manifest.Files {
+		ok, err := shouldRenderMapping(mapping, data)
+		if err != nil {
+			return 0, err
+		}
+		if !ok {
+			continue
+		}
 		sourceRoot := filepath.Join(templateRoot, filepath.FromSlash(mapping.From))
 		targetRoot := filepath.Join(destination, filepath.FromSlash(mapping.To))
 		count, err := renderTree(sourceRoot, targetRoot, data)
@@ -734,6 +742,10 @@ func renderTree(sourceRoot string, targetRoot string, data map[string]any) (int,
 		if err != nil {
 			return err
 		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
 		body, err := renderString(relative, string(payload), data)
 		if err != nil {
 			return err
@@ -741,7 +753,7 @@ func renderTree(sourceRoot string, targetRoot string, data map[string]any) (int,
 		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
 			return err
 		}
-		if err := os.WriteFile(target, []byte(body), 0o644); err != nil {
+		if err := os.WriteFile(target, []byte(body), info.Mode()); err != nil {
 			return err
 		}
 		rendered++
@@ -763,6 +775,22 @@ func renderString(name string, value string, data map[string]any) (string, error
 		return "", err
 	}
 	return output.String(), nil
+}
+
+func shouldRenderMapping(mapping TemplateFile, data map[string]any) (bool, error) {
+	if strings.TrimSpace(mapping.If) == "" {
+		return true, nil
+	}
+	value, err := renderString("mapping if", mapping.If, data)
+	if err != nil {
+		return false, err
+	}
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "", "0", "false", "no", "off":
+		return false, nil
+	default:
+		return true, nil
+	}
 }
 
 func safeJoin(root string, relative string) (string, error) {

--- a/internal/templatecatalog/catalog.go
+++ b/internal/templatecatalog/catalog.go
@@ -705,7 +705,11 @@ func renderTemplateFiles(templateRoot string, destination string, manifest Templ
 			continue
 		}
 		sourceRoot := filepath.Join(templateRoot, filepath.FromSlash(mapping.From))
-		targetRoot := filepath.Join(destination, filepath.FromSlash(mapping.To))
+		renderedTo, err := renderString("mapping to", mapping.To, data)
+		if err != nil {
+			return 0, err
+		}
+		targetRoot := filepath.Join(destination, filepath.FromSlash(renderedTo))
 		count, err := renderTree(sourceRoot, targetRoot, data)
 		if err != nil {
 			return 0, err

--- a/internal/templatecatalog/catalog_test.go
+++ b/internal/templatecatalog/catalog_test.go
@@ -184,8 +184,8 @@ func TestRenderLocalTemplate(t *testing.T) {
 	if result.Source != "local:"+packRoot {
 		t.Fatalf("expected source local:%s, got %q", packRoot, result.Source)
 	}
-	if result.Files != 1 {
-		t.Fatalf("expected one rendered file, got %d", result.Files)
+	if result.Files != 2 {
+		t.Fatalf("expected two rendered files, got %d", result.Files)
 	}
 	if result.Status != "rendered" {
 		t.Fatalf("expected rendered status, got %q", result.Status)
@@ -197,6 +197,72 @@ func TestRenderLocalTemplate(t *testing.T) {
 	}
 	if string(payload) != "hello orders\n" {
 		t.Fatalf("expected rendered file payload, got %q", payload)
+	}
+}
+
+func TestRenderSkipsConditionalMappings(t *testing.T) {
+	registryRoot, packRoot := writeConditionalRenderablePack(t)
+	destination := t.TempDir()
+
+	result, err := SourceFetcher{}.Render(context.Background(), RenderOptions{
+		RegistrySource: registryRoot,
+		TemplateName:   "examples/renderable",
+		Destination:    destination,
+		Values: map[string]string{
+			"Name":   "orders",
+			"Flavor": "pro",
+		},
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if result.Files != 2 {
+		t.Fatalf("expected two rendered files, got %d", result.Files)
+	}
+	for _, want := range []string{
+		filepath.Join(destination, "orders.txt"),
+		filepath.Join(destination, "overrides", "pro.txt"),
+	} {
+		if _, err := os.Stat(want); err != nil {
+			t.Fatalf("expected rendered file %s: %v", want, err)
+		}
+	}
+	for _, unwanted := range []string{
+		filepath.Join(destination, "overrides", "enterprise.txt"),
+	} {
+		if _, err := os.Stat(unwanted); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("expected %s to be skipped, got %v", unwanted, err)
+		}
+	}
+	if result.Source != "local:"+packRoot {
+		t.Fatalf("expected source local:%s, got %q", packRoot, result.Source)
+	}
+}
+
+func TestRenderPreservesExecutableMode(t *testing.T) {
+	registryRoot, _ := writeRenderablePack(t)
+	destination := t.TempDir()
+
+	result, err := SourceFetcher{}.Render(context.Background(), RenderOptions{
+		RegistrySource: registryRoot,
+		TemplateName:   "examples/renderable",
+		Destination:    destination,
+		Values: map[string]string{
+			"Name": "orders",
+		},
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if result.Files != 2 {
+		t.Fatalf("expected two rendered files, got %d", result.Files)
+	}
+	info, err := os.Stat(filepath.Join(destination, "bin", "run.sh"))
+	if err != nil {
+		t.Fatalf("stat rendered script: %v", err)
+	}
+	if info.Mode().Perm() != 0o755 {
+		t.Fatalf("expected executable mode 0755, got %o", info.Mode().Perm())
 	}
 }
 
@@ -820,6 +886,56 @@ files:
     to: .
 `)
 	writeFile(t, filepath.Join(packRoot, "renderable", "files"), "{{ .Name }}.txt", "hello {{ .Name }}\n")
+	writeFileMode(t, filepath.Join(packRoot, "renderable", "files", "bin"), "run.sh", "#!/bin/sh\necho hi\n", 0o755)
+
+	registryRoot := t.TempDir()
+	writeFile(t, registryRoot, registryFileName, fmt.Sprintf(`apiVersion: galaxio.io/v1
+kind: TemplateRegistry
+packs:
+  - name: examples
+    source: local:%s
+`, packRoot))
+
+	return registryRoot, packRoot
+}
+
+func writeConditionalRenderablePack(t *testing.T) (string, string) {
+	t.Helper()
+
+	packRoot := t.TempDir()
+	writeFile(t, packRoot, packFileName, `apiVersion: galaxio.io/v1
+kind: TemplatePack
+name: examples
+version: 0.1.0
+templates:
+  - name: renderable
+    version: 1.2.3
+    path: renderable
+`)
+	writeFile(t, filepath.Join(packRoot, "renderable"), templateFileName, `apiVersion: galaxio.io/v1
+kind: Template
+name: renderable
+engine: go-template
+inputs:
+  Name:
+    type: string
+    default: default
+  Flavor:
+    type: string
+    default: basic
+files:
+  - from: files/base
+    to: .
+  - from: files/overrides/pro
+    to: overrides
+    if: '{{ eq .Flavor "pro" }}'
+  - from: files/overrides/enterprise
+    to: overrides
+    if: '{{ eq .Flavor "enterprise" }}'
+`)
+	writeFile(t, filepath.Join(packRoot, "renderable", "files", "base"), "{{ .Name }}.txt", "hello {{ .Name }}\n")
+	writeFile(t, filepath.Join(packRoot, "renderable", "files", "overrides", "pro"), "pro.txt", "pro\n")
+	writeFile(t, filepath.Join(packRoot, "renderable", "files", "overrides", "enterprise"), "enterprise.txt", "enterprise\n")
 
 	registryRoot := t.TempDir()
 	writeFile(t, registryRoot, registryFileName, fmt.Sprintf(`apiVersion: galaxio.io/v1
@@ -853,6 +969,18 @@ func writeFile(t *testing.T, root string, name string, content string) {
 		t.Fatalf("create dir: %v", err)
 	}
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+}
+
+func writeFileMode(t *testing.T, root string, name string, content string, mode os.FileMode) {
+	t.Helper()
+
+	path := filepath.Join(root, name)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("create dir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), mode); err != nil {
 		t.Fatalf("write file: %v", err)
 	}
 }

--- a/internal/templatecatalog/catalog_test.go
+++ b/internal/templatecatalog/catalog_test.go
@@ -239,6 +239,256 @@ func TestRenderSkipsConditionalMappings(t *testing.T) {
 	}
 }
 
+func TestRenderSupportsTemplatedMappingDestination(t *testing.T) {
+	registryRoot := t.TempDir()
+	packRoot := t.TempDir()
+
+	writeFile(t, packRoot, packFileName, `apiVersion: galaxio.io/v1
+kind: TemplatePack
+name: examples
+version: 0.1.0
+templates:
+  - name: renderable
+    version: 1.2.3
+    path: renderable
+`)
+	writeFile(t, filepath.Join(packRoot, "renderable"), templateFileName, `apiVersion: galaxio.io/v1
+kind: Template
+name: renderable
+engine: go-template
+inputs:
+  PackagePath:
+    type: string
+    default: org/example
+  NameWord:
+    type: string
+    default: orders
+files:
+  - from: files/src/test/scala/{{ .PackagePath }}/{{ .NameWord }}/Debug.scala
+    to: src/test/scala/{{ .PackagePath }}/{{ .NameWord }}/Debug.scala
+`)
+	writeFile(t, filepath.Join(packRoot, "renderable", "files", "src", "test", "scala", "{{ .PackagePath }}", "{{ .NameWord }}"), "Debug.scala", "package test\n")
+	writeFile(t, registryRoot, registryFileName, fmt.Sprintf(`apiVersion: galaxio.io/v1
+kind: TemplateRegistry
+packs:
+  - name: examples
+    source: local:%s
+`, packRoot))
+
+	destination := t.TempDir()
+	result, err := SourceFetcher{}.Render(context.Background(), RenderOptions{
+		RegistrySource: registryRoot,
+		TemplateName:   "examples/renderable",
+		Destination:    destination,
+		Values: map[string]string{
+			"PackagePath": "org/example/performance",
+			"NameWord":    "ordersapi",
+		},
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if result.Files != 1 {
+		t.Fatalf("expected one rendered file, got %d", result.Files)
+	}
+	rendered := filepath.Join(destination, "src", "test", "scala", "org", "example", "performance", "ordersapi", "Debug.scala")
+	if _, err := os.Stat(rendered); err != nil {
+		t.Fatalf("expected rendered file %s: %v", rendered, err)
+	}
+}
+
+func TestRenderSkipsConditionalMappingWithFalsyValues(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{"empty", ""},
+		{"zero", "0"},
+		{"false", "false"},
+		{"no", "no"},
+		{"off", "off"},
+		{"FALSE", "FALSE"},
+		{"No", "No"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			packRoot := t.TempDir()
+			writeFile(t, packRoot, packFileName, `apiVersion: galaxio.io/v1
+kind: TemplatePack
+name: examples
+version: 0.1.0
+templates:
+  - name: renderable
+    version: 1.0.0
+    path: renderable
+`)
+			writeFile(t, filepath.Join(packRoot, "renderable"), templateFileName, `apiVersion: galaxio.io/v1
+kind: Template
+name: renderable
+engine: go-template
+inputs:
+  Name:
+    type: string
+    default: svc
+  EnableKafka:
+    type: string
+    default: "false"
+files:
+  - from: files/base
+    to: .
+  - from: files/kafka
+    to: kafka
+    if: '{{ .EnableKafka }}'
+`)
+			writeFile(t, filepath.Join(packRoot, "renderable", "files", "base"), "main.txt", "main\n")
+			writeFile(t, filepath.Join(packRoot, "renderable", "files", "kafka"), "kafka.txt", "kafka\n")
+
+			registryRoot := t.TempDir()
+			writeFile(t, registryRoot, registryFileName, fmt.Sprintf(`apiVersion: galaxio.io/v1
+kind: TemplateRegistry
+packs:
+  - name: examples
+    source: local:%s
+`, packRoot))
+
+			destination := t.TempDir()
+			result, err := SourceFetcher{}.Render(context.Background(), RenderOptions{
+				RegistrySource: registryRoot,
+				TemplateName:   "examples/renderable",
+				Destination:    destination,
+				Values:         map[string]string{"Name": "svc", "EnableKafka": tt.value},
+			})
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			if result.Files != 1 {
+				t.Fatalf("expected one rendered file (base only), got %d", result.Files)
+			}
+			if _, err := os.Stat(filepath.Join(destination, "kafka", "kafka.txt")); !errors.Is(err, os.ErrNotExist) {
+				t.Fatalf("expected kafka dir to be skipped, got %v", err)
+			}
+		})
+	}
+}
+
+func TestRenderIncludesConditionalMappingWithTruthyValues(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{"yes", "yes"},
+		{"y", "y"},
+		{"true", "true"},
+		{"1", "1"},
+		{"on", "on"},
+		{"arbitrary", "something"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			packRoot := t.TempDir()
+			writeFile(t, packRoot, packFileName, `apiVersion: galaxio.io/v1
+kind: TemplatePack
+name: examples
+version: 0.1.0
+templates:
+  - name: renderable
+    version: 1.0.0
+    path: renderable
+`)
+			writeFile(t, filepath.Join(packRoot, "renderable"), templateFileName, `apiVersion: galaxio.io/v1
+kind: Template
+name: renderable
+engine: go-template
+inputs:
+  Name:
+    type: string
+    default: svc
+  EnableKafka:
+    type: string
+    default: "false"
+files:
+  - from: files/base
+    to: .
+  - from: files/kafka
+    to: kafka
+    if: '{{ .EnableKafka }}'
+`)
+			writeFile(t, filepath.Join(packRoot, "renderable", "files", "base"), "main.txt", "main\n")
+			writeFile(t, filepath.Join(packRoot, "renderable", "files", "kafka"), "kafka.txt", "kafka\n")
+
+			registryRoot := t.TempDir()
+			writeFile(t, registryRoot, registryFileName, fmt.Sprintf(`apiVersion: galaxio.io/v1
+kind: TemplateRegistry
+packs:
+  - name: examples
+    source: local:%s
+`, packRoot))
+
+			destination := t.TempDir()
+			result, err := SourceFetcher{}.Render(context.Background(), RenderOptions{
+				RegistrySource: registryRoot,
+				TemplateName:   "examples/renderable",
+				Destination:    destination,
+				Values:         map[string]string{"Name": "svc", "EnableKafka": tt.value},
+			})
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			if result.Files != 2 {
+				t.Fatalf("expected two rendered files, got %d", result.Files)
+			}
+			if _, err := os.Stat(filepath.Join(destination, "kafka", "kafka.txt")); err != nil {
+				t.Fatalf("expected kafka file to exist: %v", err)
+			}
+		})
+	}
+}
+
+func TestRenderErrorsOnMissingIfVariable(t *testing.T) {
+	packRoot := t.TempDir()
+	writeFile(t, packRoot, packFileName, `apiVersion: galaxio.io/v1
+kind: TemplatePack
+name: examples
+version: 0.1.0
+templates:
+  - name: renderable
+    version: 1.0.0
+    path: renderable
+`)
+	writeFile(t, filepath.Join(packRoot, "renderable"), templateFileName, `apiVersion: galaxio.io/v1
+kind: Template
+name: renderable
+engine: go-template
+inputs:
+  Name:
+    type: string
+    default: svc
+files:
+  - from: files
+    to: .
+    if: '{{ .MissingKey }}'
+`)
+	writeFile(t, filepath.Join(packRoot, "renderable", "files"), "main.txt", "main\n")
+
+	registryRoot := t.TempDir()
+	writeFile(t, registryRoot, registryFileName, fmt.Sprintf(`apiVersion: galaxio.io/v1
+kind: TemplateRegistry
+packs:
+  - name: examples
+    source: local:%s
+`, packRoot))
+
+	_, err := SourceFetcher{}.Render(context.Background(), RenderOptions{
+		RegistrySource: registryRoot,
+		TemplateName:   "examples/renderable",
+		Destination:    t.TempDir(),
+		Values:         map[string]string{"Name": "svc"},
+	})
+	if err == nil {
+		t.Fatal("expected error for missing key in if expression")
+	}
+}
+
 func TestRenderPreservesExecutableMode(t *testing.T) {
 	registryRoot, _ := writeRenderablePack(t)
 	destination := t.TempDir()


### PR DESCRIPTION
## Summary
- add generic \ support for template file mappings
- preserve executable file modes when rendering templates
- document and test conditional mappings and executable rendering

## Verification
- go test ./internal/templatecatalog
