### PR TITLE
docs: surface template workflow in top-level README

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,13 +94,14 @@ Browse available templates:
 galaxio template list
 ```
 
-Scaffold a new project from a template:
+Scaffold a new project from a template (files are written to `--destination`,
+which defaults to the current directory):
 
 ```sh
-galaxio template init gatling/scala-sbt
+galaxio template init gatling/scala-sbt -d ./my-project
 ```
 
-Override template inputs with `--set` and choose a destination directory:
+Override template inputs with `--set`:
 
 ```sh
 galaxio template init gatling/scala-sbt --set Name=orders -d ./my-project
@@ -120,8 +121,13 @@ galaxio template list
 
 # 2. Create a project from a template
 galaxio template init gatling/scala-sbt -d ./perf-tests
+```
 
-# 3. Verify your own template pack before publishing
+### For template authors
+
+Validate a template pack before publishing:
+
+```sh
 galaxio template validate local:./my-pack
 ```
 

--- a/README.md
+++ b/README.md
@@ -83,9 +83,60 @@ galaxio update --dry-run
 galaxio update --version 0.1.1
 ```
 
-Local template examples and manifest format notes live in
-[docs/templates/README.md](docs/templates/README.md) and
-`examples/templates/`.
+## Template Workflow
+
+The CLI ships with a default registry (`github:galax-io/galaxio-template-registry`),
+so template discovery works out of the box with no configuration.
+
+Browse available templates:
+
+```sh
+galaxio template list
+```
+
+Scaffold a new project from a template:
+
+```sh
+galaxio template init gatling/scala-sbt
+```
+
+Override template inputs with `--set` and choose a destination directory:
+
+```sh
+galaxio template init gatling/scala-sbt --set Name=orders -d ./my-project
+```
+
+Validate a template pack (useful for template authors):
+
+```sh
+galaxio template validate local:../my-templates
+```
+
+### End-to-end example
+
+```sh
+# 1. See what templates are available
+galaxio template list
+
+# 2. Create a project from a template
+galaxio template init gatling/scala-sbt -d ./perf-tests
+
+# 3. Verify your own template pack before publishing
+galaxio template validate local:./my-pack
+```
+
+### Custom registries
+
+The default registry is used automatically. Run `template configure` only when
+you need a different registry:
+
+```sh
+galaxio template configure --registry github:my-org/my-registry
+galaxio template configure --show
+```
+
+For manifest format details and local examples, see
+[docs/templates/README.md](docs/templates/README.md) and `examples/templates/`.
 
 ## Exit Codes
 


### PR DESCRIPTION
## Summary

- Add a dedicated **Template Workflow** section to the top-level README covering `template list`, `template init`, `template validate`, and `template configure`
- Include an end-to-end example so newcomers can scaffold a project without opening a second document
- Explain when `template configure` is needed (custom registry) vs when it is not (default registry works automatically)

Fixes #16

## Test plan

- [ ] Verify all CLI commands shown match actual subcommand signatures
- [ ] Confirm a first-time reader can follow the workflow without referencing `docs/templates/README.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)