### PR TITLE
docs: add installation support matrix and troubleshooting guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Release binaries are built for every OS/architecture combination below.
 
 ### Option 1 — `go install` (all platforms)
 
-Requires Go 1.23 or later on your `PATH`.
+Requires Go 1.24 or later on your `PATH`.
 
 ```sh
 go install github.com/galax-io/galaxio-cli/cmd/galaxio@latest
@@ -51,14 +51,14 @@ curl -fsSL https://raw.githubusercontent.com/galax-io/galaxio-cli/main/scripts/i
 Pin a specific version:
 
 ```sh
-GALAXIO_VERSION=0.1.1 sh scripts/install.sh
+curl -fsSL https://raw.githubusercontent.com/galax-io/galaxio-cli/main/scripts/install.sh | GALAXIO_VERSION=0.1.1 sh
 ```
 
 The installer writes to `$HOME/.local/bin` by default. Override with
 `GALAXIO_BIN_DIR`:
 
 ```sh
-GALAXIO_BIN_DIR=/usr/local/bin sh scripts/install.sh
+curl -fsSL https://raw.githubusercontent.com/galax-io/galaxio-cli/main/scripts/install.sh | GALAXIO_BIN_DIR=/usr/local/bin sh
 ```
 
 ### Option 3 — Manual download (all platforms)
@@ -147,7 +147,7 @@ failures:
 | --- | --- | --- |
 | `curl: (7) Failed to connect` | Corporate proxy or firewall | Set `https_proxy` before running the installer: `https_proxy=http://proxy:port sh scripts/install.sh` |
 | `curl: (28) Connection timed out` | Slow or blocked network | Retry, or download the binary manually from a browser |
-| HTTP 403 / rate-limit error | GitHub API rate limit (60 req/h unauthenticated) | Export a GitHub token: `GITHUB_TOKEN=ghp_... sh scripts/install.sh`, or download manually |
+| HTTP 403 / rate-limit error | GitHub API rate limit (60 req/h unauthenticated) | Wait an hour, or download the binary manually from the [Releases](https://github.com/galax-io/galaxio-cli/releases) page |
 | `release asset not found` | OS/arch not in the release | Verify your platform is in the support matrix above; fall back to `go install` |
 
 #### Checksum verification fails

--- a/README.md
+++ b/README.md
@@ -13,28 +13,155 @@ completion, and stable exit codes for scripts and CI.
 
 ## Install
 
-Install the latest version with Go:
+### Supported platforms
+
+Release binaries are built for every OS/architecture combination below.
+
+| OS | Arch | `go install` | Shell installer | Manual download |
+| --- | --- | :---: | :---: | :---: |
+| macOS (darwin) | amd64 | yes | yes | yes |
+| macOS (darwin) | arm64 (Apple Silicon) | yes | yes | yes |
+| Linux | amd64 | yes | yes | yes |
+| Linux | arm64 | yes | yes | yes |
+| Windows | amd64 | yes | no* | yes |
+| Windows | arm64 | yes | no* | yes |
+
+> \* The shell installer targets POSIX shells. Windows users should use
+> `go install` or download a `.zip` from GitHub Releases (see below).
+
+### Option 1 — `go install` (all platforms)
+
+Requires Go 1.23 or later on your `PATH`.
 
 ```sh
 go install github.com/galax-io/galaxio-cli/cmd/galaxio@latest
 ```
 
-Install a tagged release binary:
+The binary is placed in `$(go env GOPATH)/bin`. Make sure that directory is on
+your `PATH` (see [PATH setup](#path-setup)).
+
+### Option 2 — Shell installer (macOS and Linux)
+
+Prerequisites: `curl`, `shasum`, `tar`, `unzip`.
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/galax-io/galaxio-cli/main/scripts/install.sh | sh
+```
+
+Pin a specific version:
+
+```sh
 GALAXIO_VERSION=0.1.1 sh scripts/install.sh
 ```
 
-The installer writes to `$HOME/.local/bin` by default. Add it to `PATH` if
-needed:
+The installer writes to `$HOME/.local/bin` by default. Override with
+`GALAXIO_BIN_DIR`:
 
 ```sh
+GALAXIO_BIN_DIR=/usr/local/bin sh scripts/install.sh
+```
+
+### Option 3 — Manual download (all platforms)
+
+Download a prebuilt binary from the
+[GitHub Releases](https://github.com/galax-io/galaxio-cli/releases) page.
+Archives are named `galaxio_<version>_<os>_<arch>.tar.gz` (`.zip` on Windows).
+
+1. Download the archive for your platform.
+2. Verify the checksum against `checksums.txt` from the same release.
+3. Extract the `galaxio` binary (or `galaxio.exe` on Windows).
+4. Move it to a directory on your `PATH`.
+
+### Windows recommended path
+
+Windows does not ship with a POSIX shell, so use one of:
+
+1. **`go install`** — simplest if Go is already installed.
+2. **Manual download** — grab the `.zip` from GitHub Releases, extract
+   `galaxio.exe`, and place it in a directory listed in your `Path` environment
+   variable (for example `C:\Users\<you>\bin`).
+
+To add a directory to your `Path` on Windows:
+
+```
+setx Path "%Path%;C:\Users\<you>\bin"
+```
+
+Then open a **new** terminal for the change to take effect.
+
+### PATH setup
+
+After installing, verify the binary is reachable:
+
+```sh
+galaxio --version
+```
+
+If the command is not found, add the install location to your `PATH`:
+
+**macOS / Linux (shell installer default)**
+
+```sh
+# Add to ~/.bashrc, ~/.zshrc, or equivalent:
 export PATH="$HOME/.local/bin:$PATH"
 ```
 
-Or download a prebuilt binary from the
-[GitHub Releases](https://github.com/galax-io/galaxio-cli/releases) page.
+**macOS / Linux (`go install` default)**
+
+```sh
+export PATH="$(go env GOPATH)/bin:$PATH"
+```
+
+**Windows**
+
+```
+setx Path "%Path%;%USERPROFILE%\go\bin"
+```
+
+### Troubleshooting
+
+#### `command not found` after install
+
+The binary is not on your `PATH`. Check where it was installed and add that
+directory (see [PATH setup](#path-setup)). Open a new terminal session after
+changing `PATH`.
+
+```sh
+# Find the binary:
+ls ~/.local/bin/galaxio        # shell installer default
+ls "$(go env GOPATH)/bin/galaxio"  # go install default
+```
+
+#### `unsupported arch` from the shell installer
+
+The installer only recognises `x86_64`/`amd64` and `arm64`/`aarch64`. If
+`uname -m` returns something else (for example `armv7l` on a 32-bit ARM
+device), use `go install` to cross-compile for your architecture instead.
+
+#### GitHub API / network / proxy errors
+
+The shell installer downloads from the GitHub API and Releases CDN. Common
+failures:
+
+| Symptom | Likely cause | Fix |
+| --- | --- | --- |
+| `curl: (7) Failed to connect` | Corporate proxy or firewall | Set `https_proxy` before running the installer: `https_proxy=http://proxy:port sh scripts/install.sh` |
+| `curl: (28) Connection timed out` | Slow or blocked network | Retry, or download the binary manually from a browser |
+| HTTP 403 / rate-limit error | GitHub API rate limit (60 req/h unauthenticated) | Export a GitHub token: `GITHUB_TOKEN=ghp_... sh scripts/install.sh`, or download manually |
+| `release asset not found` | OS/arch not in the release | Verify your platform is in the support matrix above; fall back to `go install` |
+
+#### Checksum verification fails
+
+If `shasum` reports a mismatch, the download may be corrupted or tampered with.
+Delete the partial install and retry:
+
+```sh
+rm -f ~/.local/bin/galaxio
+curl -fsSL https://raw.githubusercontent.com/galax-io/galaxio-cli/main/scripts/install.sh | sh
+```
+
+If the problem persists, download the archive and `checksums.txt` manually and
+compare.
 
 ## Usage
 


### PR DESCRIPTION
## Summary

Adds comprehensive installation documentation to the README covering all supported platforms, install methods, and common failure modes.

## Changes

- **Support matrix**: OS (macOS, Linux, Windows) x arch (amd64, arm64) x install method (`go install`, shell installer, manual download)
- **PATH setup**: Platform-specific instructions for macOS, Linux, and Windows
- **Shell installer prerequisites**: Documents required tools (`curl`, `shasum`, `tar`, `unzip`)
- **Windows recommended path**: Explicit guidance for Windows users (no POSIX shell)
- **Troubleshooting section**:
  - `command not found` after install
  - `unsupported arch` from the shell installer
  - GitHub API / network / proxy errors (with symptom-cause-fix table)
  - Checksum verification failures

## Testing

- Documentation-only change; verified markdown renders correctly

Fixes #15