### PR TITLE
feat: add codegen generators for swagger, har, and postman

### DIFF
--- a/cmd/galaxio/errors.go
+++ b/cmd/galaxio/errors.go
@@ -50,5 +50,5 @@ func exitCode(err error) int {
 		return exitRuntime
 	}
 
-	return exitUsage
+	return exitRuntime
 }

--- a/cmd/galaxio/generate.go
+++ b/cmd/galaxio/generate.go
@@ -1,22 +1,70 @@
 package main
 
 import (
-	"fmt"
+	"strings"
 
 	"github.com/galax-io/galaxio-cli/internal/featureflags"
 	"github.com/spf13/cobra"
 )
 
+type generateOptions struct {
+	from          string
+	template      string
+	dest          string
+	pkg           string
+	ifExists      string
+	registry      string
+	valuesFile    string
+	values        []string
+	init          bool
+	includeStatic bool
+}
+
 func newGenerateCommand() *cobra.Command {
-	return &cobra.Command{
+	opts := &generateOptions{
+		template: "scala-sbt",
+		dest:     ".",
+		pkg:      "com.example.perf",
+		ifExists: "suffix",
+	}
+
+	cmd := &cobra.Command{
 		Use:   "generate",
-		Short: "Experimental project generation commands.",
-		Long:  "Experimental project generation commands.",
-		Args:  cobra.ArbitraryArgs,
+		Short: "Generate code from API specifications.",
+		Long:  "Generate Gatling load-test source files from supported API specifications.",
+		Example: strings.Join([]string{
+			"  galaxio generate swagger --from ./petstore.yaml",
+			"  galaxio generate har --from ./recording.har",
+			"  galaxio generate postman --from ./collection.json",
+			"  galaxio generate swagger --from ./petstore.yaml --dest ./out",
+			"  galaxio generate swagger --from ./petstore.yaml --package org.example.performance --output json",
+		}, "\n"),
+		Args: func(cmd *cobra.Command, args []string) error {
+			if err := cobra.NoArgs(cmd, args); err != nil {
+				return UsageError{Err: err}
+			}
+			return nil
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return RuntimeError{Err: fmt.Errorf("generate is enabled but not implemented yet")}
+			return cmd.Help()
 		},
 	}
+
+	cmd.PersistentFlags().StringVar(&opts.from, "from", "", "path to the source Swagger file")
+	cmd.PersistentFlags().StringVar(&opts.template, "template", opts.template, "Gatling DSL template pack")
+	cmd.PersistentFlags().StringVar(&opts.dest, "dest", opts.dest, "output directory")
+	cmd.PersistentFlags().StringVar(&opts.pkg, "package", opts.pkg, "base package for generated code")
+	cmd.PersistentFlags().StringVar(&opts.ifExists, "if-exists", opts.ifExists, "conflict strategy: suffix, merge, skip, overwrite")
+	cmd.PersistentFlags().StringVar(&opts.registry, "registry", "", "template registry source used by --init")
+	cmd.PersistentFlags().StringVar(&opts.valuesFile, "values", "", "YAML file with template values used by --init")
+	cmd.PersistentFlags().StringArrayVar(&opts.values, "set", nil, "template value in Key=Value form used by --init")
+	cmd.PersistentFlags().BoolVar(&opts.init, "init", false, "initialize a full project scaffold before overlaying generated files")
+
+	cmd.AddCommand(newGenerateSwaggerCommand(opts))
+	cmd.AddCommand(newGenerateHARCommand(opts))
+	cmd.AddCommand(newGeneratePostmanCommand(opts))
+
+	return cmd
 }
 
 func validateExperimentalCommand(args []string) error {

--- a/cmd/galaxio/generate.go
+++ b/cmd/galaxio/generate.go
@@ -8,15 +8,17 @@ import (
 )
 
 type generateOptions struct {
-	from          string
-	template      string
-	dest          string
-	pkg           string
-	ifExists      string
-	registry      string
-	valuesFile    string
-	values        []string
-	init          bool
+	from        string
+	template    string
+	dest        string
+	pkg         string
+	ifExists    string
+	ifExistsSet bool
+	registry    string
+	valuesFile  string
+	values      []string
+	init        bool
+	// includeStatic is only used by `generate har`.
 	includeStatic bool
 }
 

--- a/cmd/galaxio/generate_har.go
+++ b/cmd/galaxio/generate_har.go
@@ -10,20 +10,21 @@ import (
 )
 
 type generateHAROutput struct {
-	Template         string `json:"template"`
-	Source           string `json:"source"`
-	Destination      string `json:"destination"`
-	Package          string `json:"package"`
-	IfExists         string `json:"ifExists"`
-	Init             bool   `json:"init"`
-	IncludeStatic    bool   `json:"includeStatic"`
-	Actions          int    `json:"actions"`
-	Scenarios        int    `json:"scenarios"`
-	BodyFiles        int    `json:"bodyFiles"`
-	FilesWritten     int    `json:"filesWritten"`
-	FilesSkipped     int    `json:"filesSkipped"`
-	FilesConflicted  int    `json:"filesConflicted"`
-	FilesOverwritten int    `json:"filesOverwritten"`
+	Template         string   `json:"template"`
+	Source           string   `json:"source"`
+	Destination      string   `json:"destination"`
+	Package          string   `json:"package"`
+	IfExists         string   `json:"ifExists"`
+	Warnings         []string `json:"warnings,omitempty"`
+	Init             bool     `json:"init"`
+	IncludeStatic    bool     `json:"includeStatic"`
+	Actions          int      `json:"actions"`
+	Scenarios        int      `json:"scenarios"`
+	BodyFiles        int      `json:"bodyFiles"`
+	FilesWritten     int      `json:"filesWritten"`
+	FilesSkipped     int      `json:"filesSkipped"`
+	FilesConflicted  int      `json:"filesConflicted"`
+	FilesOverwritten int      `json:"filesOverwritten"`
 }
 
 func newGenerateHARCommand(opts *generateOptions) *cobra.Command {
@@ -51,6 +52,9 @@ func newGenerateHARCommand(opts *generateOptions) *cobra.Command {
 			result, err := runGenerateHAR(cmd.Context(), *opts)
 			if err != nil {
 				return err
+			}
+			if err := writeGenerateWarnings(cmd.ErrOrStderr(), result.Warnings); err != nil {
+				return RuntimeError{Err: err}
 			}
 
 			if output == outputJSON {
@@ -112,6 +116,7 @@ func runGenerateHAR(ctx context.Context, opts generateOptions) (generateHAROutpu
 		Destination:      summary.destination,
 		Package:          opts.pkg,
 		IfExists:         opts.ifExists,
+		Warnings:         summary.warnings,
 		Init:             opts.init,
 		IncludeStatic:    opts.includeStatic,
 		Actions:          summary.actions,

--- a/cmd/galaxio/generate_har.go
+++ b/cmd/galaxio/generate_har.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/galax-io/galaxio-cli/internal/codegen/parser"
+	"github.com/spf13/cobra"
+)
+
+type generateHAROutput struct {
+	Template         string `json:"template"`
+	Source           string `json:"source"`
+	Destination      string `json:"destination"`
+	Package          string `json:"package"`
+	IfExists         string `json:"ifExists"`
+	Init             bool   `json:"init"`
+	IncludeStatic    bool   `json:"includeStatic"`
+	Actions          int    `json:"actions"`
+	Scenarios        int    `json:"scenarios"`
+	BodyFiles        int    `json:"bodyFiles"`
+	FilesWritten     int    `json:"filesWritten"`
+	FilesSkipped     int    `json:"filesSkipped"`
+	FilesConflicted  int    `json:"filesConflicted"`
+	FilesOverwritten int    `json:"filesOverwritten"`
+}
+
+func newGenerateHARCommand(opts *generateOptions) *cobra.Command {
+	var output string
+
+	cmd := &cobra.Command{
+		Use:   "har",
+		Short: "Generate Gatling scripts from HAR 1.2 recordings.",
+		Long:  "Generate Scala/sbt Gatling source files from a browser-exported HAR 1.2 recording.",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if err := cobra.NoArgs(cmd, args); err != nil {
+				return UsageError{Err: err}
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateOutputFormat(output); err != nil {
+				return err
+			}
+			if err := validateGenerateTemplateOptions(*opts); err != nil {
+				return err
+			}
+
+			result, err := runGenerateHAR(cmd.Context(), *opts, cmd.Flags().Changed("if-exists"))
+			if err != nil {
+				return err
+			}
+
+			if output == outputJSON {
+				if err := writeJSON(cmd.OutOrStdout(), result); err != nil {
+					return RuntimeError{Err: err}
+				}
+				return nil
+			}
+
+			if isQuiet(cmd) {
+				return nil
+			}
+
+			if _, err := fmt.Fprintf(
+				cmd.OutOrStdout(),
+				"Generated %d action files, %d scenario files, %d body files in %s\nFiles written: %d, skipped: %d, conflicts: %d, overwritten: %d\n",
+				result.Actions,
+				result.Scenarios,
+				result.BodyFiles,
+				result.Destination,
+				result.FilesWritten,
+				result.FilesSkipped,
+				result.FilesConflicted,
+				result.FilesOverwritten,
+			); err != nil {
+				return RuntimeError{Err: err}
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&output, "output", "o", outputText, "output format: text or json")
+	cmd.Flags().BoolVar(&opts.includeStatic, "include-static", false, "include static resources such as images, CSS, JS, and fonts")
+
+	return cmd
+}
+
+func runGenerateHAR(ctx context.Context, opts generateOptions, ifExistsExplicit bool) (generateHAROutput, error) {
+	payload, err := os.ReadFile(opts.from)
+	if err != nil {
+		return generateHAROutput{}, RuntimeError{Err: fmt.Errorf("read har input: %w", err)}
+	}
+
+	summary, err := runGenerateSpec(ctx, opts, ifExistsExplicit, payload, func(ctx context.Context, payload []byte) (*generateExecutionSummary, error) {
+		spec, err := parser.NewHARParser(opts.includeStatic).Parse(ctx, payload)
+		if err != nil {
+			return nil, RuntimeError{Err: fmt.Errorf("parse har input: %w", err)}
+		}
+		return renderAndWriteSpec(ctx, opts, ifExistsExplicit, spec)
+	})
+	if err != nil {
+		return generateHAROutput{}, err
+	}
+
+	return generateHAROutput{
+		Template:         opts.template,
+		Source:           opts.from,
+		Destination:      summary.destination,
+		Package:          opts.pkg,
+		IfExists:         opts.ifExists,
+		Init:             opts.init,
+		IncludeStatic:    opts.includeStatic,
+		Actions:          summary.actions,
+		Scenarios:        summary.scenarios,
+		BodyFiles:        summary.bodyFiles,
+		FilesWritten:     summary.written,
+		FilesSkipped:     summary.skipped,
+		FilesConflicted:  summary.conflicted,
+		FilesOverwritten: summary.overwritten,
+	}, nil
+}
+
+func runGenerateSpec(ctx context.Context, opts generateOptions, ifExistsExplicit bool, payload []byte, run func(context.Context, []byte) (*generateExecutionSummary, error)) (*generateExecutionSummary, error) {
+	return run(ctx, payload)
+}

--- a/cmd/galaxio/generate_har.go
+++ b/cmd/galaxio/generate_har.go
@@ -46,8 +46,9 @@ func newGenerateHARCommand(opts *generateOptions) *cobra.Command {
 			if err := validateGenerateTemplateOptions(*opts); err != nil {
 				return err
 			}
+			opts.ifExistsSet = cmd.Flags().Changed("if-exists")
 
-			result, err := runGenerateHAR(cmd.Context(), *opts, cmd.Flags().Changed("if-exists"))
+			result, err := runGenerateHAR(cmd.Context(), *opts)
 			if err != nil {
 				return err
 			}
@@ -88,18 +89,18 @@ func newGenerateHARCommand(opts *generateOptions) *cobra.Command {
 	return cmd
 }
 
-func runGenerateHAR(ctx context.Context, opts generateOptions, ifExistsExplicit bool) (generateHAROutput, error) {
+func runGenerateHAR(ctx context.Context, opts generateOptions) (generateHAROutput, error) {
 	payload, err := os.ReadFile(opts.from)
 	if err != nil {
 		return generateHAROutput{}, RuntimeError{Err: fmt.Errorf("read har input: %w", err)}
 	}
 
-	summary, err := runGenerateSpec(ctx, opts, ifExistsExplicit, payload, func(ctx context.Context, payload []byte) (*generateExecutionSummary, error) {
+	summary, err := runGenerateSpec(ctx, opts, payload, func(ctx context.Context, payload []byte) (*generateExecutionSummary, error) {
 		spec, err := parser.NewHARParser(opts.includeStatic).Parse(ctx, payload)
 		if err != nil {
 			return nil, RuntimeError{Err: fmt.Errorf("parse har input: %w", err)}
 		}
-		return renderAndWriteSpec(ctx, opts, ifExistsExplicit, spec)
+		return renderAndWriteSpec(ctx, opts, spec)
 	})
 	if err != nil {
 		return generateHAROutput{}, err
@@ -123,6 +124,6 @@ func runGenerateHAR(ctx context.Context, opts generateOptions, ifExistsExplicit 
 	}, nil
 }
 
-func runGenerateSpec(ctx context.Context, opts generateOptions, ifExistsExplicit bool, payload []byte, run func(context.Context, []byte) (*generateExecutionSummary, error)) (*generateExecutionSummary, error) {
+func runGenerateSpec(ctx context.Context, opts generateOptions, payload []byte, run func(context.Context, []byte) (*generateExecutionSummary, error)) (*generateExecutionSummary, error) {
 	return run(ctx, payload)
 }

--- a/cmd/galaxio/generate_har_test.go
+++ b/cmd/galaxio/generate_har_test.go
@@ -1,0 +1,170 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/galax-io/galaxio-cli/internal/featureflags"
+)
+
+func TestGenerateHARWritesFilesAndPrintsSummary(t *testing.T) {
+	t.Setenv(featureflags.Generate.EnvVar, "true")
+
+	dest := t.TempDir()
+	source := filepath.Join("..", "..", "internal", "codegen", "testdata", "har-application-json.json")
+
+	code, stdout, stderr := runCLI(
+		"generate",
+		"har",
+		"--from", source,
+		"--template", "scala-sbt",
+		"--dest", dest,
+		"--package", "org.example.har",
+	)
+
+	if code != exitOK {
+		t.Fatalf("expected exit code %d, got %d, stderr %q", exitOK, code, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	for _, want := range []string{
+		"Generated 1 action files, 1 scenario files, 1 body files",
+		"Files written: 3, skipped: 0, conflicts: 0, overwritten: 0",
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("expected summary output to contain %q, got %q", want, stdout)
+		}
+	}
+
+	for _, file := range []string{
+		"cases/HttpbinOrgActions.scala",
+		"scenarios/HttpbinOrgScenario.scala",
+		"resources/bodies/postPost.json",
+	} {
+		if _, err := os.Stat(filepath.Join(dest, file)); err != nil {
+			t.Fatalf("expected generated file %s: %v", file, err)
+		}
+	}
+
+	actions, err := os.ReadFile(filepath.Join(dest, "cases", "HttpbinOrgActions.scala"))
+	if err != nil {
+		t.Fatalf("read generated actions: %v", err)
+	}
+	payload := string(actions)
+	for _, want := range []string{
+		`package org.example.har.cases`,
+		`.body(ElFileBody("bodies/postPost.json")).asJson`,
+	} {
+		if !strings.Contains(payload, want) {
+			t.Fatalf("expected actions file to contain %q, got %q", want, payload)
+		}
+	}
+	if strings.Contains(payload, "/assets/app.js") {
+		t.Fatalf("expected static asset to be filtered by default, got %q", payload)
+	}
+
+	bodyPayload, err := os.ReadFile(filepath.Join(dest, "resources", "bodies", "postPost.json"))
+	if err != nil {
+		t.Fatalf("read generated body: %v", err)
+	}
+	if !strings.Contains(string(bodyPayload), `"arr_mix_nested": {}`) {
+		t.Fatalf("expected recorded JSON payload to be preserved, got %q", bodyPayload)
+	}
+}
+
+func TestGenerateHARIncludeStaticKeepsAssetRequests(t *testing.T) {
+	t.Setenv(featureflags.Generate.EnvVar, "true")
+
+	dest := t.TempDir()
+	source := filepath.Join("..", "..", "internal", "codegen", "testdata", "har-static-asset.json")
+
+	code, stdout, stderr := runCLI(
+		"generate",
+		"har",
+		"--from", source,
+		"--dest", dest,
+		"--include-static",
+	)
+
+	if code != exitOK {
+		t.Fatalf("expected exit code %d, got %d, stderr %q", exitOK, code, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, "Generated 1 action files, 1 scenario files, 0 body files") {
+		t.Fatalf("expected summary output, got %q", stdout)
+	}
+
+	actions, err := os.ReadFile(filepath.Join(dest, "cases", "HttpbinOrgActions.scala"))
+	if err != nil {
+		t.Fatalf("read generated actions: %v", err)
+	}
+	if !strings.Contains(string(actions), "/assets/app.js") {
+		t.Fatalf("expected static asset request in actions file, got %q", actions)
+	}
+}
+
+func TestGenerateHARSupportsJSONOutput(t *testing.T) {
+	t.Setenv(featureflags.Generate.EnvVar, "true")
+
+	dest := t.TempDir()
+	source := filepath.Join("..", "..", "internal", "codegen", "testdata", "har-application-json.json")
+
+	code, stdout, stderr := runCLI(
+		"generate",
+		"har",
+		"--from", source,
+		"--dest", dest,
+		"--output", "json",
+	)
+
+	if code != exitOK {
+		t.Fatalf("expected exit code %d, got %d, stderr %q", exitOK, code, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var result generateHAROutput
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("decode json output: %v; output %q", err, stdout)
+	}
+	if result.Template != "scala-sbt" {
+		t.Fatalf("expected template scala-sbt, got %q", result.Template)
+	}
+	if result.IncludeStatic {
+		t.Fatalf("expected includeStatic false by default, got %#v", result)
+	}
+	if result.Actions != 1 || result.Scenarios != 1 || result.BodyFiles != 1 {
+		t.Fatalf("unexpected counts: %#v", result)
+	}
+	if result.FilesWritten != 3 {
+		t.Fatalf("expected 3 files written, got %d", result.FilesWritten)
+	}
+}
+
+func TestGenerateHARRejectsInvalidHAR(t *testing.T) {
+	t.Setenv(featureflags.Generate.EnvVar, "true")
+
+	source := filepath.Join(t.TempDir(), "invalid.har")
+	if err := os.WriteFile(source, []byte(`{"log":{}}`), 0o644); err != nil {
+		t.Fatalf("write invalid har: %v", err)
+	}
+
+	code, stdout, stderr := runCLI("generate", "har", "--from", source)
+
+	if code != exitRuntime {
+		t.Fatalf("expected exit code %d, got %d", exitRuntime, code)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "parse har input") {
+		t.Fatalf("expected parse error, got %q", stderr)
+	}
+}

--- a/cmd/galaxio/generate_postman.go
+++ b/cmd/galaxio/generate_postman.go
@@ -45,8 +45,9 @@ func newGeneratePostmanCommand(opts *generateOptions) *cobra.Command {
 			if err := validateGenerateTemplateOptions(*opts); err != nil {
 				return err
 			}
+			opts.ifExistsSet = cmd.Flags().Changed("if-exists")
 
-			result, err := runGeneratePostman(cmd.Context(), *opts, cmd.Flags().Changed("if-exists"))
+			result, err := runGeneratePostman(cmd.Context(), *opts)
 			if err != nil {
 				return err
 			}
@@ -85,7 +86,7 @@ func newGeneratePostmanCommand(opts *generateOptions) *cobra.Command {
 	return cmd
 }
 
-func runGeneratePostman(ctx context.Context, opts generateOptions, ifExistsExplicit bool) (generatePostmanOutput, error) {
+func runGeneratePostman(ctx context.Context, opts generateOptions) (generatePostmanOutput, error) {
 	payload, err := os.ReadFile(opts.from)
 	if err != nil {
 		return generatePostmanOutput{}, RuntimeError{Err: fmt.Errorf("read postman input: %w", err)}
@@ -96,7 +97,7 @@ func runGeneratePostman(ctx context.Context, opts generateOptions, ifExistsExpli
 		return generatePostmanOutput{}, RuntimeError{Err: fmt.Errorf("parse postman input: %w", err)}
 	}
 
-	summary, err := renderAndWriteSpec(ctx, opts, ifExistsExplicit, spec)
+	summary, err := renderAndWriteSpec(ctx, opts, spec)
 	if err != nil {
 		return generatePostmanOutput{}, err
 	}

--- a/cmd/galaxio/generate_postman.go
+++ b/cmd/galaxio/generate_postman.go
@@ -10,19 +10,20 @@ import (
 )
 
 type generatePostmanOutput struct {
-	Template         string `json:"template"`
-	Source           string `json:"source"`
-	Destination      string `json:"destination"`
-	Package          string `json:"package"`
-	IfExists         string `json:"ifExists"`
-	Init             bool   `json:"init"`
-	Actions          int    `json:"actions"`
-	Scenarios        int    `json:"scenarios"`
-	BodyFiles        int    `json:"bodyFiles"`
-	FilesWritten     int    `json:"filesWritten"`
-	FilesSkipped     int    `json:"filesSkipped"`
-	FilesConflicted  int    `json:"filesConflicted"`
-	FilesOverwritten int    `json:"filesOverwritten"`
+	Template         string   `json:"template"`
+	Source           string   `json:"source"`
+	Destination      string   `json:"destination"`
+	Package          string   `json:"package"`
+	IfExists         string   `json:"ifExists"`
+	Warnings         []string `json:"warnings,omitempty"`
+	Init             bool     `json:"init"`
+	Actions          int      `json:"actions"`
+	Scenarios        int      `json:"scenarios"`
+	BodyFiles        int      `json:"bodyFiles"`
+	FilesWritten     int      `json:"filesWritten"`
+	FilesSkipped     int      `json:"filesSkipped"`
+	FilesConflicted  int      `json:"filesConflicted"`
+	FilesOverwritten int      `json:"filesOverwritten"`
 }
 
 func newGeneratePostmanCommand(opts *generateOptions) *cobra.Command {
@@ -50,6 +51,9 @@ func newGeneratePostmanCommand(opts *generateOptions) *cobra.Command {
 			result, err := runGeneratePostman(cmd.Context(), *opts)
 			if err != nil {
 				return err
+			}
+			if err := writeGenerateWarnings(cmd.ErrOrStderr(), result.Warnings); err != nil {
+				return RuntimeError{Err: err}
 			}
 
 			if output == outputJSON {
@@ -108,6 +112,7 @@ func runGeneratePostman(ctx context.Context, opts generateOptions) (generatePost
 		Destination:      summary.destination,
 		Package:          opts.pkg,
 		IfExists:         opts.ifExists,
+		Warnings:         summary.warnings,
 		Init:             opts.init,
 		Actions:          summary.actions,
 		Scenarios:        summary.scenarios,

--- a/cmd/galaxio/generate_postman.go
+++ b/cmd/galaxio/generate_postman.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/galax-io/galaxio-cli/internal/codegen/parser"
+	"github.com/spf13/cobra"
+)
+
+type generatePostmanOutput struct {
+	Template         string `json:"template"`
+	Source           string `json:"source"`
+	Destination      string `json:"destination"`
+	Package          string `json:"package"`
+	IfExists         string `json:"ifExists"`
+	Init             bool   `json:"init"`
+	Actions          int    `json:"actions"`
+	Scenarios        int    `json:"scenarios"`
+	BodyFiles        int    `json:"bodyFiles"`
+	FilesWritten     int    `json:"filesWritten"`
+	FilesSkipped     int    `json:"filesSkipped"`
+	FilesConflicted  int    `json:"filesConflicted"`
+	FilesOverwritten int    `json:"filesOverwritten"`
+}
+
+func newGeneratePostmanCommand(opts *generateOptions) *cobra.Command {
+	var output string
+
+	cmd := &cobra.Command{
+		Use:   "postman",
+		Short: "Generate Gatling scripts from Postman collections.",
+		Long:  "Generate Scala/sbt Gatling source files from a Postman Collection v2.1 export.",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if err := cobra.NoArgs(cmd, args); err != nil {
+				return UsageError{Err: err}
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateOutputFormat(output); err != nil {
+				return err
+			}
+			if err := validateGenerateTemplateOptions(*opts); err != nil {
+				return err
+			}
+
+			result, err := runGeneratePostman(cmd.Context(), *opts, cmd.Flags().Changed("if-exists"))
+			if err != nil {
+				return err
+			}
+
+			if output == outputJSON {
+				if err := writeJSON(cmd.OutOrStdout(), result); err != nil {
+					return RuntimeError{Err: err}
+				}
+				return nil
+			}
+
+			if isQuiet(cmd) {
+				return nil
+			}
+
+			if _, err := fmt.Fprintf(
+				cmd.OutOrStdout(),
+				"Generated %d action files, %d scenario files, %d body files in %s\nFiles written: %d, skipped: %d, conflicts: %d, overwritten: %d\n",
+				result.Actions,
+				result.Scenarios,
+				result.BodyFiles,
+				result.Destination,
+				result.FilesWritten,
+				result.FilesSkipped,
+				result.FilesConflicted,
+				result.FilesOverwritten,
+			); err != nil {
+				return RuntimeError{Err: err}
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&output, "output", "o", outputText, "output format: text or json")
+	return cmd
+}
+
+func runGeneratePostman(ctx context.Context, opts generateOptions, ifExistsExplicit bool) (generatePostmanOutput, error) {
+	payload, err := os.ReadFile(opts.from)
+	if err != nil {
+		return generatePostmanOutput{}, RuntimeError{Err: fmt.Errorf("read postman input: %w", err)}
+	}
+
+	spec, err := parser.NewPostmanParser().Parse(ctx, payload)
+	if err != nil {
+		return generatePostmanOutput{}, RuntimeError{Err: fmt.Errorf("parse postman input: %w", err)}
+	}
+
+	summary, err := renderAndWriteSpec(ctx, opts, ifExistsExplicit, spec)
+	if err != nil {
+		return generatePostmanOutput{}, err
+	}
+
+	return generatePostmanOutput{
+		Template:         opts.template,
+		Source:           opts.from,
+		Destination:      summary.destination,
+		Package:          opts.pkg,
+		IfExists:         opts.ifExists,
+		Init:             opts.init,
+		Actions:          summary.actions,
+		Scenarios:        summary.scenarios,
+		BodyFiles:        summary.bodyFiles,
+		FilesWritten:     summary.written,
+		FilesSkipped:     summary.skipped,
+		FilesConflicted:  summary.conflicted,
+		FilesOverwritten: summary.overwritten,
+	}, nil
+}

--- a/cmd/galaxio/generate_postman_test.go
+++ b/cmd/galaxio/generate_postman_test.go
@@ -1,0 +1,191 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/galax-io/galaxio-cli/internal/featureflags"
+)
+
+func TestGeneratePostmanWritesFilesAndPrintsSummary(t *testing.T) {
+	t.Setenv(featureflags.Generate.EnvVar, "true")
+
+	dest := t.TempDir()
+	source := filepath.Join("..", "..", "internal", "codegen", "testdata", "sample-collection.json")
+
+	code, stdout, stderr := runCLI(
+		"generate",
+		"postman",
+		"--from", source,
+		"--template", "scala-sbt",
+		"--dest", dest,
+		"--package", "org.example.postman",
+	)
+
+	if code != exitOK {
+		t.Fatalf("expected exit code %d, got %d, stderr %q", exitOK, code, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	for _, want := range []string{
+		"Generated 3 action files, 2 scenario files, 1 body files",
+		"Files written: 6, skipped: 0, conflicts: 0, overwritten: 0",
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("expected summary output to contain %q, got %q", want, stdout)
+		}
+	}
+
+	for _, file := range []string{
+		"cases/AuthActions.scala",
+		"cases/OrdersActions.scala",
+		"cases/DefaultActions.scala",
+		"scenarios/OrdersScenario.scala",
+		"scenarios/DefaultScenario.scala",
+		"resources/bodies/createOrder.json",
+	} {
+		if _, err := os.Stat(filepath.Join(dest, file)); err != nil {
+			t.Fatalf("expected generated file %s: %v", file, err)
+		}
+	}
+
+	actions, err := os.ReadFile(filepath.Join(dest, "cases", "OrdersActions.scala"))
+	if err != nil {
+		t.Fatalf("read generated actions: %v", err)
+	}
+	payload := string(actions)
+	for _, want := range []string{
+		`package org.example.postman.cases`,
+		`.post("/api/v1/orders")`,
+		`.header("X-Trace-Id", "${traceId}")`,
+		`.get("/api/v1/orders/${orderId}")`,
+		`.queryParam("expand", "${expand}")`,
+		`.body(ElFileBody("bodies/createOrder.json")).asJson`,
+		`TODO prerequest script: pm.variables.set("traceId", "trace-456");`,
+	} {
+		if !strings.Contains(payload, want) {
+			t.Fatalf("expected actions file to contain %q, got %q", want, payload)
+		}
+	}
+
+	bodyPayload, err := os.ReadFile(filepath.Join(dest, "resources", "bodies", "createOrder.json"))
+	if err != nil {
+		t.Fatalf("read generated body: %v", err)
+	}
+	if !strings.Contains(string(bodyPayload), `"sku": "${sku}"`) {
+		t.Fatalf("expected variable mapping in generated body, got %q", bodyPayload)
+	}
+}
+
+func TestGeneratePostmanSupportsJSONOutput(t *testing.T) {
+	t.Setenv(featureflags.Generate.EnvVar, "true")
+
+	dest := t.TempDir()
+	source := filepath.Join("..", "..", "internal", "codegen", "testdata", "sample-collection.json")
+
+	code, stdout, stderr := runCLI(
+		"generate",
+		"postman",
+		"--from", source,
+		"--dest", dest,
+		"--output", "json",
+	)
+
+	if code != exitOK {
+		t.Fatalf("expected exit code %d, got %d, stderr %q", exitOK, code, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var result generatePostmanOutput
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("decode json output: %v; output %q", err, stdout)
+	}
+	if result.Template != "scala-sbt" {
+		t.Fatalf("expected template scala-sbt, got %q", result.Template)
+	}
+	if result.Actions != 3 || result.Scenarios != 2 || result.BodyFiles != 1 {
+		t.Fatalf("unexpected counts: %#v", result)
+	}
+	if result.FilesWritten != 6 {
+		t.Fatalf("expected 6 files written, got %d", result.FilesWritten)
+	}
+}
+
+func TestGeneratePostmanRejectsInvalidCollection(t *testing.T) {
+	t.Setenv(featureflags.Generate.EnvVar, "true")
+
+	source := filepath.Join(t.TempDir(), "invalid-postman.json")
+	if err := os.WriteFile(source, []byte(`{"info":{}}`), 0o644); err != nil {
+		t.Fatalf("write invalid collection: %v", err)
+	}
+
+	code, stdout, stderr := runCLI("generate", "postman", "--from", source)
+
+	if code != exitRuntime {
+		t.Fatalf("expected exit code %d, got %d", exitRuntime, code)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "parse postman input") {
+		t.Fatalf("expected parse error, got %q", stderr)
+	}
+}
+
+func TestGeneratePostmanSupportsZitadelFixture(t *testing.T) {
+	t.Setenv(featureflags.Generate.EnvVar, "true")
+
+	dest := t.TempDir()
+	source := filepath.Join("..", "..", "internal", "codegen", "testdata", "zitadel.postman_collection.json")
+
+	code, stdout, stderr := runCLI(
+		"generate",
+		"postman",
+		"--from", source,
+		"--template", "scala-sbt",
+		"--dest", dest,
+		"--package", "org.example.zitadel",
+	)
+
+	if code != exitOK {
+		t.Fatalf("expected exit code %d, got %d, stderr %q", exitOK, code, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, "Generated") {
+		t.Fatalf("expected generation summary, got %q", stdout)
+	}
+
+	for _, file := range []string{
+		"cases/AuthActions.scala",
+		"cases/DefaultActions.scala",
+		"scenarios/DefaultScenario.scala",
+		"resources/bodies/addZitadelProject.json",
+	} {
+		if _, err := os.Stat(filepath.Join(dest, file)); err != nil {
+			t.Fatalf("expected generated file %s: %v", file, err)
+		}
+	}
+
+	actions, err := os.ReadFile(filepath.Join(dest, "cases", "DefaultActions.scala"))
+	if err != nil {
+		t.Fatalf("read generated actions: %v", err)
+	}
+	payload := string(actions)
+	for _, want := range []string{
+		`.post("${yourZitadelDomain}/management/v1/projects")`,
+		`.get("http://localhost:3000/protected-get")`,
+		`.body(ElFileBody("bodies/addZitadelProject.json")).asJson`,
+	} {
+		if !strings.Contains(payload, want) {
+			t.Fatalf("expected actions file to contain %q, got %q", want, payload)
+		}
+	}
+}

--- a/cmd/galaxio/generate_swagger.go
+++ b/cmd/galaxio/generate_swagger.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
-	"unicode"
 
 	"github.com/galax-io/galaxio-cli/internal/codegen"
 	"github.com/galax-io/galaxio-cli/internal/codegen/parser"
@@ -65,8 +64,9 @@ func newGenerateSwaggerCommand(opts *generateOptions) *cobra.Command {
 			if err := validateGenerateTemplateOptions(*opts); err != nil {
 				return err
 			}
+			opts.ifExistsSet = cmd.Flags().Changed("if-exists")
 
-			result, err := runGenerateSwagger(cmd.Context(), *opts, cmd.Flags().Changed("if-exists"))
+			result, err := runGenerateSwagger(cmd.Context(), *opts)
 			if err != nil {
 				return err
 			}
@@ -119,7 +119,7 @@ func validateGenerateTemplateOptions(opts generateOptions) error {
 	return nil
 }
 
-func runGenerateSwagger(ctx context.Context, opts generateOptions, ifExistsExplicit bool) (generateSwaggerOutput, error) {
+func runGenerateSwagger(ctx context.Context, opts generateOptions) (generateSwaggerOutput, error) {
 	payload, err := os.ReadFile(opts.from)
 	if err != nil {
 		return generateSwaggerOutput{}, RuntimeError{Err: fmt.Errorf("read swagger input: %w", err)}
@@ -130,7 +130,7 @@ func runGenerateSwagger(ctx context.Context, opts generateOptions, ifExistsExpli
 		return generateSwaggerOutput{}, RuntimeError{Err: fmt.Errorf("parse swagger input: %w", err)}
 	}
 
-	summary, err := renderAndWriteSpec(ctx, opts, ifExistsExplicit, spec)
+	summary, err := renderAndWriteSpec(ctx, opts, spec)
 	if err != nil {
 		return generateSwaggerOutput{}, err
 	}
@@ -152,10 +152,10 @@ func runGenerateSwagger(ctx context.Context, opts generateOptions, ifExistsExpli
 	}, nil
 }
 
-func renderAndWriteSpec(ctx context.Context, opts generateOptions, ifExistsExplicit bool, spec *codegen.Spec) (*generateExecutionSummary, error) {
+func renderAndWriteSpec(ctx context.Context, opts generateOptions, spec *codegen.Spec) (*generateExecutionSummary, error) {
 	renderPackage := opts.pkg
 	if opts.init {
-		nameWord := deriveNameWord(filepath.Base(opts.dest))
+		nameWord := codegen.DeriveNameWord(filepath.Base(opts.dest))
 		if templateValues, err := resolveGenerateTemplateValues(opts); err == nil {
 			if value := strings.TrimSpace(templateValues["NameWord"]); value != "" {
 				nameWord = value
@@ -169,7 +169,7 @@ func renderAndWriteSpec(ctx context.Context, opts generateOptions, ifExistsExpli
 		return nil, RuntimeError{Err: fmt.Errorf("render generated files: %w", err)}
 	}
 
-	conflictSummary, err := writeGeneratedProject(ctx, opts, ifExistsExplicit, files)
+	conflictSummary, err := writeGeneratedProject(ctx, opts, files)
 	if err != nil {
 		return nil, RuntimeError{Err: fmt.Errorf("write generated files: %w", err)}
 	}
@@ -192,7 +192,7 @@ func renderAndWriteSpec(ctx context.Context, opts generateOptions, ifExistsExpli
 	}, nil
 }
 
-func writeGeneratedProject(ctx context.Context, opts generateOptions, ifExistsExplicit bool, files []renderer.OutputFile) (writeSummary, error) {
+func writeGeneratedProject(ctx context.Context, opts generateOptions, files []renderer.OutputFile) (writeSummary, error) {
 	if !opts.init {
 		return writeRenderedFiles(opts.dest, files, opts.ifExists)
 	}
@@ -201,7 +201,7 @@ func writeGeneratedProject(ctx context.Context, opts generateOptions, ifExistsEx
 	if err != nil {
 		return writeSummary{}, err
 	}
-	if destExists && !ifExistsExplicit {
+	if destExists && !opts.ifExistsSet {
 		return writeSummary{}, fmt.Errorf("destination %q already contains files; rerun with --if-exists to allow project regeneration", opts.dest)
 	}
 
@@ -254,13 +254,13 @@ func writeRenderedFiles(dest string, files []renderer.OutputFile, strategy strin
 			return writeSummary{}, err
 		}
 		switch result.Status {
-		case "written":
+		case codegen.ConflictStatusWritten:
 			summary.Written++
-		case "skipped":
+		case codegen.ConflictStatusSkipped:
 			summary.Skipped++
-		case "conflict":
+		case codegen.ConflictStatusConflict:
 			summary.Conflicted++
-		case "overwritten":
+		case codegen.ConflictStatusOverwritten:
 			summary.Overwritten++
 		}
 	}
@@ -284,7 +284,7 @@ func resolveGenerateTemplateValues(opts generateOptions) (map[string]string, err
 		values["Name"] = filepath.Base(opts.dest)
 	}
 	if strings.TrimSpace(values["NameWord"]) == "" {
-		values["NameWord"] = deriveNameWord(values["Name"])
+		values["NameWord"] = codegen.DeriveNameWord(values["Name"])
 	}
 	values["Package"] = opts.pkg
 	values["PackagePath"] = strings.ReplaceAll(opts.pkg, ".", "/")
@@ -297,37 +297,6 @@ func templateRefForGenerateTemplate(templateName string) string {
 		return templateName
 	}
 	return "gatling/" + templateName
-}
-
-func deriveNameWord(value string) string {
-	words := splitGenerateWords(value)
-	if len(words) == 0 {
-		return "generated"
-	}
-
-	var builder strings.Builder
-	for _, word := range words {
-		builder.WriteString(strings.ToLower(word))
-	}
-	return builder.String()
-}
-
-func splitGenerateWords(value string) []string {
-	replacer := strings.NewReplacer("/", " ", "-", " ", "_", " ", ".", " ")
-	value = replacer.Replace(value)
-
-	parts := strings.FieldsFunc(value, func(r rune) bool {
-		return unicode.IsSpace(r) || unicode.IsPunct(r)
-	})
-
-	result := make([]string, 0, len(parts))
-	for _, part := range parts {
-		part = strings.TrimSpace(part)
-		if part != "" {
-			result = append(result, part)
-		}
-	}
-	return result
 }
 
 func dirHasEntries(path string) (bool, error) {

--- a/cmd/galaxio/generate_swagger.go
+++ b/cmd/galaxio/generate_swagger.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -18,19 +19,20 @@ import (
 const generateTemplateScalaSBT = "scala-sbt"
 
 type generateSwaggerOutput struct {
-	Template         string `json:"template"`
-	Source           string `json:"source"`
-	Destination      string `json:"destination"`
-	Package          string `json:"package"`
-	IfExists         string `json:"ifExists"`
-	Init             bool   `json:"init"`
-	Actions          int    `json:"actions"`
-	Scenarios        int    `json:"scenarios"`
-	BodyFiles        int    `json:"bodyFiles"`
-	FilesWritten     int    `json:"filesWritten"`
-	FilesSkipped     int    `json:"filesSkipped"`
-	FilesConflicted  int    `json:"filesConflicted"`
-	FilesOverwritten int    `json:"filesOverwritten"`
+	Template         string   `json:"template"`
+	Source           string   `json:"source"`
+	Destination      string   `json:"destination"`
+	Package          string   `json:"package"`
+	IfExists         string   `json:"ifExists"`
+	Warnings         []string `json:"warnings,omitempty"`
+	Init             bool     `json:"init"`
+	Actions          int      `json:"actions"`
+	Scenarios        int      `json:"scenarios"`
+	BodyFiles        int      `json:"bodyFiles"`
+	FilesWritten     int      `json:"filesWritten"`
+	FilesSkipped     int      `json:"filesSkipped"`
+	FilesConflicted  int      `json:"filesConflicted"`
+	FilesOverwritten int      `json:"filesOverwritten"`
 }
 
 type generateExecutionSummary struct {
@@ -42,6 +44,7 @@ type generateExecutionSummary struct {
 	skipped     int
 	conflicted  int
 	overwritten int
+	warnings    []string
 }
 
 func newGenerateSwaggerCommand(opts *generateOptions) *cobra.Command {
@@ -69,6 +72,9 @@ func newGenerateSwaggerCommand(opts *generateOptions) *cobra.Command {
 			result, err := runGenerateSwagger(cmd.Context(), *opts)
 			if err != nil {
 				return err
+			}
+			if err := writeGenerateWarnings(cmd.ErrOrStderr(), result.Warnings); err != nil {
+				return RuntimeError{Err: err}
 			}
 
 			if output == outputJSON {
@@ -141,6 +147,7 @@ func runGenerateSwagger(ctx context.Context, opts generateOptions) (generateSwag
 		Destination:      summary.destination,
 		Package:          opts.pkg,
 		IfExists:         opts.ifExists,
+		Warnings:         summary.warnings,
 		Init:             opts.init,
 		Actions:          summary.actions,
 		Scenarios:        summary.scenarios,
@@ -189,6 +196,7 @@ func renderAndWriteSpec(ctx context.Context, opts generateOptions, spec *codegen
 		skipped:     conflictSummary.Skipped,
 		conflicted:  conflictSummary.Conflicted,
 		overwritten: conflictSummary.Overwritten,
+		warnings:    conflictSummary.Warnings,
 	}, nil
 }
 
@@ -243,6 +251,7 @@ type writeSummary struct {
 	Skipped     int
 	Conflicted  int
 	Overwritten int
+	Warnings    []string
 }
 
 func writeRenderedFiles(dest string, files []renderer.OutputFile, strategy string) (writeSummary, error) {
@@ -258,6 +267,9 @@ func writeRenderedFiles(dest string, files []renderer.OutputFile, strategy strin
 			summary.Written++
 		case codegen.ConflictStatusSkipped:
 			summary.Skipped++
+			if strategy == codegen.IfExistsSkip {
+				summary.Warnings = append(summary.Warnings, fmt.Sprintf("warning: skipped existing file %s", result.Path))
+			}
 		case codegen.ConflictStatusConflict:
 			summary.Conflicted++
 		case codegen.ConflictStatusOverwritten:
@@ -265,6 +277,15 @@ func writeRenderedFiles(dest string, files []renderer.OutputFile, strategy strin
 		}
 	}
 	return summary, nil
+}
+
+func writeGenerateWarnings(stderr io.Writer, warnings []string) error {
+	for _, warning := range warnings {
+		if _, err := fmt.Fprintln(stderr, warning); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func resolveGenerateTemplateValues(opts generateOptions) (map[string]string, error) {

--- a/cmd/galaxio/generate_swagger.go
+++ b/cmd/galaxio/generate_swagger.go
@@ -1,0 +1,411 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"unicode"
+
+	"github.com/galax-io/galaxio-cli/internal/codegen"
+	"github.com/galax-io/galaxio-cli/internal/codegen/parser"
+	"github.com/galax-io/galaxio-cli/internal/codegen/renderer"
+	"github.com/galax-io/galaxio-cli/internal/templatecatalog"
+	"github.com/spf13/cobra"
+)
+
+const generateTemplateScalaSBT = "scala-sbt"
+
+type generateSwaggerOutput struct {
+	Template         string `json:"template"`
+	Source           string `json:"source"`
+	Destination      string `json:"destination"`
+	Package          string `json:"package"`
+	IfExists         string `json:"ifExists"`
+	Init             bool   `json:"init"`
+	Actions          int    `json:"actions"`
+	Scenarios        int    `json:"scenarios"`
+	BodyFiles        int    `json:"bodyFiles"`
+	FilesWritten     int    `json:"filesWritten"`
+	FilesSkipped     int    `json:"filesSkipped"`
+	FilesConflicted  int    `json:"filesConflicted"`
+	FilesOverwritten int    `json:"filesOverwritten"`
+}
+
+type generateExecutionSummary struct {
+	destination string
+	actions     int
+	scenarios   int
+	bodyFiles   int
+	written     int
+	skipped     int
+	conflicted  int
+	overwritten int
+}
+
+func newGenerateSwaggerCommand(opts *generateOptions) *cobra.Command {
+	var output string
+
+	cmd := &cobra.Command{
+		Use:   "swagger",
+		Short: "Generate Gatling scripts from Swagger 2.0.",
+		Long:  "Generate Scala/sbt Gatling source files from a Swagger 2.0 specification.",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if err := cobra.NoArgs(cmd, args); err != nil {
+				return UsageError{Err: err}
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateOutputFormat(output); err != nil {
+				return err
+			}
+			if err := validateGenerateTemplateOptions(*opts); err != nil {
+				return err
+			}
+
+			result, err := runGenerateSwagger(cmd.Context(), *opts, cmd.Flags().Changed("if-exists"))
+			if err != nil {
+				return err
+			}
+
+			if output == outputJSON {
+				if err := writeJSON(cmd.OutOrStdout(), result); err != nil {
+					return RuntimeError{Err: err}
+				}
+				return nil
+			}
+
+			if isQuiet(cmd) {
+				return nil
+			}
+
+			if _, err := fmt.Fprintf(
+				cmd.OutOrStdout(),
+				"Generated %d action files, %d scenario files, %d body files in %s\nFiles written: %d, skipped: %d, conflicts: %d, overwritten: %d\n",
+				result.Actions,
+				result.Scenarios,
+				result.BodyFiles,
+				result.Destination,
+				result.FilesWritten,
+				result.FilesSkipped,
+				result.FilesConflicted,
+				result.FilesOverwritten,
+			); err != nil {
+				return RuntimeError{Err: err}
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&output, "output", "o", outputText, "output format: text or json")
+
+	return cmd
+}
+
+func validateGenerateTemplateOptions(opts generateOptions) error {
+	if strings.TrimSpace(opts.from) == "" {
+		return UsageError{Err: fmt.Errorf("required flag(s) \"from\" not set")}
+	}
+	if strings.TrimSpace(opts.template) != generateTemplateScalaSBT {
+		return UsageError{Err: fmt.Errorf("unknown generate template %q", opts.template)}
+	}
+	if err := codegen.ValidateIfExistsStrategy(opts.ifExists); err != nil {
+		return UsageError{Err: err}
+	}
+	return nil
+}
+
+func runGenerateSwagger(ctx context.Context, opts generateOptions, ifExistsExplicit bool) (generateSwaggerOutput, error) {
+	payload, err := os.ReadFile(opts.from)
+	if err != nil {
+		return generateSwaggerOutput{}, RuntimeError{Err: fmt.Errorf("read swagger input: %w", err)}
+	}
+
+	spec, err := parser.NewSwaggerParser().Parse(ctx, payload)
+	if err != nil {
+		return generateSwaggerOutput{}, RuntimeError{Err: fmt.Errorf("parse swagger input: %w", err)}
+	}
+
+	summary, err := renderAndWriteSpec(ctx, opts, ifExistsExplicit, spec)
+	if err != nil {
+		return generateSwaggerOutput{}, err
+	}
+
+	return generateSwaggerOutput{
+		Template:         opts.template,
+		Source:           opts.from,
+		Destination:      summary.destination,
+		Package:          opts.pkg,
+		IfExists:         opts.ifExists,
+		Init:             opts.init,
+		Actions:          summary.actions,
+		Scenarios:        summary.scenarios,
+		BodyFiles:        summary.bodyFiles,
+		FilesWritten:     summary.written,
+		FilesSkipped:     summary.skipped,
+		FilesConflicted:  summary.conflicted,
+		FilesOverwritten: summary.overwritten,
+	}, nil
+}
+
+func renderAndWriteSpec(ctx context.Context, opts generateOptions, ifExistsExplicit bool, spec *codegen.Spec) (*generateExecutionSummary, error) {
+	renderPackage := opts.pkg
+	if opts.init {
+		nameWord := deriveNameWord(filepath.Base(opts.dest))
+		if templateValues, err := resolveGenerateTemplateValues(opts); err == nil {
+			if value := strings.TrimSpace(templateValues["NameWord"]); value != "" {
+				nameWord = value
+			}
+		}
+		renderPackage = opts.pkg + "." + nameWord
+	}
+
+	files, err := renderer.NewRenderer().Render(spec, renderer.RenderOptions{Package: renderPackage})
+	if err != nil {
+		return nil, RuntimeError{Err: fmt.Errorf("render generated files: %w", err)}
+	}
+
+	conflictSummary, err := writeGeneratedProject(ctx, opts, ifExistsExplicit, files)
+	if err != nil {
+		return nil, RuntimeError{Err: fmt.Errorf("write generated files: %w", err)}
+	}
+
+	absDest, err := filepath.Abs(opts.dest)
+	if err != nil {
+		return nil, RuntimeError{Err: fmt.Errorf("resolve destination: %w", err)}
+	}
+
+	actions, scenarios, bodyFiles := countGeneratedFiles(files)
+	return &generateExecutionSummary{
+		destination: absDest,
+		actions:     actions,
+		scenarios:   scenarios,
+		bodyFiles:   bodyFiles,
+		written:     conflictSummary.Written,
+		skipped:     conflictSummary.Skipped,
+		conflicted:  conflictSummary.Conflicted,
+		overwritten: conflictSummary.Overwritten,
+	}, nil
+}
+
+func writeGeneratedProject(ctx context.Context, opts generateOptions, ifExistsExplicit bool, files []renderer.OutputFile) (writeSummary, error) {
+	if !opts.init {
+		return writeRenderedFiles(opts.dest, files, opts.ifExists)
+	}
+
+	destExists, err := dirHasEntries(opts.dest)
+	if err != nil {
+		return writeSummary{}, err
+	}
+	if destExists && !ifExistsExplicit {
+		return writeSummary{}, fmt.Errorf("destination %q already contains files; rerun with --if-exists to allow project regeneration", opts.dest)
+	}
+
+	templateValues, err := resolveGenerateTemplateValues(opts)
+	if err != nil {
+		return writeSummary{}, err
+	}
+	registrySource, err := resolveTemplateRegistry(opts.registry)
+	if err != nil {
+		return writeSummary{}, err
+	}
+
+	scaffoldDir, err := os.MkdirTemp("", "galaxio-generate-init-*")
+	if err != nil {
+		return writeSummary{}, err
+	}
+	defer os.RemoveAll(scaffoldDir)
+
+	_, err = (templatecatalog.SourceFetcher{}).Render(ctx, templatecatalog.RenderOptions{
+		RegistrySource: registrySource,
+		TemplateName:   templateRefForGenerateTemplate(opts.template),
+		Destination:    scaffoldDir,
+		Values:         templateValues,
+	})
+	if err != nil {
+		return writeSummary{}, err
+	}
+
+	projectFiles, err := collectInitProjectFiles(scaffoldDir, files, templateValues)
+	if err != nil {
+		return writeSummary{}, err
+	}
+
+	return writeRenderedFiles(opts.dest, projectFiles, opts.ifExists)
+}
+
+type writeSummary struct {
+	Written     int
+	Skipped     int
+	Conflicted  int
+	Overwritten int
+}
+
+func writeRenderedFiles(dest string, files []renderer.OutputFile, strategy string) (writeSummary, error) {
+	var summary writeSummary
+	for _, file := range files {
+		target := filepath.Join(dest, file.Path)
+		result, err := codegen.WriteFileWithStrategy(target, file.Content, strategy)
+		if err != nil {
+			return writeSummary{}, err
+		}
+		switch result.Status {
+		case "written":
+			summary.Written++
+		case "skipped":
+			summary.Skipped++
+		case "conflict":
+			summary.Conflicted++
+		case "overwritten":
+			summary.Overwritten++
+		}
+	}
+	return summary, nil
+}
+
+func resolveGenerateTemplateValues(opts generateOptions) (map[string]string, error) {
+	values, err := loadTemplateValues(opts.valuesFile)
+	if err != nil {
+		return nil, err
+	}
+	setValues, err := parseTemplateValues(opts.values)
+	if err != nil {
+		return nil, err
+	}
+	for key, value := range setValues {
+		values[key] = value
+	}
+
+	if strings.TrimSpace(values["Name"]) == "" {
+		values["Name"] = filepath.Base(opts.dest)
+	}
+	if strings.TrimSpace(values["NameWord"]) == "" {
+		values["NameWord"] = deriveNameWord(values["Name"])
+	}
+	values["Package"] = opts.pkg
+	values["PackagePath"] = strings.ReplaceAll(opts.pkg, ".", "/")
+
+	return values, nil
+}
+
+func templateRefForGenerateTemplate(templateName string) string {
+	if strings.Contains(templateName, "/") {
+		return templateName
+	}
+	return "gatling/" + templateName
+}
+
+func deriveNameWord(value string) string {
+	words := splitGenerateWords(value)
+	if len(words) == 0 {
+		return "generated"
+	}
+
+	var builder strings.Builder
+	for _, word := range words {
+		builder.WriteString(strings.ToLower(word))
+	}
+	return builder.String()
+}
+
+func splitGenerateWords(value string) []string {
+	replacer := strings.NewReplacer("/", " ", "-", " ", "_", " ", ".", " ")
+	value = replacer.Replace(value)
+
+	parts := strings.FieldsFunc(value, func(r rune) bool {
+		return unicode.IsSpace(r) || unicode.IsPunct(r)
+	})
+
+	result := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			result = append(result, part)
+		}
+	}
+	return result
+}
+
+func dirHasEntries(path string) (bool, error) {
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return len(entries) > 0, nil
+}
+
+func collectInitProjectFiles(scaffoldDir string, generated []renderer.OutputFile, values map[string]string) ([]renderer.OutputFile, error) {
+	files := make([]renderer.OutputFile, 0, len(generated))
+
+	if err := filepath.WalkDir(scaffoldDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+
+		payload, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+
+		rel, err := filepath.Rel(scaffoldDir, path)
+		if err != nil {
+			return err
+		}
+		files = append(files, renderer.OutputFile{
+			Path:    filepath.ToSlash(rel),
+			Content: payload,
+		})
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	packagePath := values["PackagePath"]
+	nameWord := values["NameWord"]
+	for _, file := range generated {
+		files = append(files, renderer.OutputFile{
+			Path:    overlayGeneratedPath(file.Path, packagePath, nameWord),
+			Content: file.Content,
+		})
+	}
+
+	sort.Slice(files, func(i, j int) bool {
+		return files[i].Path < files[j].Path
+	})
+	return files, nil
+}
+
+func overlayGeneratedPath(path string, packagePath string, nameWord string) string {
+	switch {
+	case strings.HasPrefix(path, "cases/"), strings.HasPrefix(path, "scenarios/"):
+		return filepath.ToSlash(filepath.Join("src", "test", "scala", packagePath, nameWord, path))
+	case strings.HasPrefix(path, "resources/"):
+		return filepath.ToSlash(filepath.Join("src", "test", path))
+	default:
+		return path
+	}
+}
+
+func countGeneratedFiles(files []renderer.OutputFile) (actions int, scenarios int, bodyFiles int) {
+	for _, file := range files {
+		switch {
+		case strings.HasPrefix(file.Path, "cases/"):
+			actions++
+		case strings.HasPrefix(file.Path, "scenarios/"):
+			scenarios++
+		case strings.HasPrefix(file.Path, "resources/bodies/"):
+			bodyFiles++
+		}
+	}
+	return actions, scenarios, bodyFiles
+}

--- a/cmd/galaxio/generate_swagger_helpers_test.go
+++ b/cmd/galaxio/generate_swagger_helpers_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/galax-io/galaxio-cli/internal/codegen"
+	"github.com/galax-io/galaxio-cli/internal/codegen/renderer"
+)
+
+func TestWriteRenderedFilesCountsStatuses(t *testing.T) {
+	dest := t.TempDir()
+
+	if err := os.MkdirAll(filepath.Join(dest, "cases"), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dest, "cases", "Skip.scala"), []byte("same"), 0o644); err != nil {
+		t.Fatalf("WriteFile(skip) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dest, "cases", "Overwrite.scala"), []byte("old"), 0o644); err != nil {
+		t.Fatalf("WriteFile(overwrite) error = %v", err)
+	}
+
+	files := []renderer.OutputFile{
+		{Path: "cases/New.scala", Content: []byte("new")},
+		{Path: "cases/Skip.scala", Content: []byte("same")},
+		{Path: "cases/Overwrite.scala", Content: []byte("fresh")},
+	}
+
+	written, err := writeRenderedFiles(dest, files[:1], codegen.IfExistsOverwrite)
+	if err != nil {
+		t.Fatalf("writeRenderedFiles(new) error = %v", err)
+	}
+	if written.Written != 1 || written.Skipped != 0 || written.Overwritten != 0 {
+		t.Fatalf("unexpected new-file summary: %#v", written)
+	}
+
+	skipped, err := writeRenderedFiles(dest, files[1:2], codegen.IfExistsOverwrite)
+	if err != nil {
+		t.Fatalf("writeRenderedFiles(skip) error = %v", err)
+	}
+	if skipped.Skipped != 1 || skipped.Written != 0 || skipped.Overwritten != 0 {
+		t.Fatalf("unexpected skipped summary: %#v", skipped)
+	}
+
+	overwritten, err := writeRenderedFiles(dest, files[2:], codegen.IfExistsOverwrite)
+	if err != nil {
+		t.Fatalf("writeRenderedFiles(overwrite) error = %v", err)
+	}
+	if overwritten.Overwritten != 1 || overwritten.Written != 0 || overwritten.Skipped != 0 {
+		t.Fatalf("unexpected overwritten summary: %#v", overwritten)
+	}
+}
+
+func TestResolveGenerateTemplateValuesDerivesNameWord(t *testing.T) {
+	values, err := resolveGenerateTemplateValues(generateOptions{
+		dest: filepath.Join(t.TempDir(), "Orders API"),
+		pkg:  "org.example.perf",
+	})
+	if err != nil {
+		t.Fatalf("resolveGenerateTemplateValues() error = %v", err)
+	}
+
+	if values["NameWord"] != "ordersapi" {
+		t.Fatalf("expected ordersapi, got %q", values["NameWord"])
+	}
+	if values["PackagePath"] != "org/example/perf" {
+		t.Fatalf("expected package path org/example/perf, got %q", values["PackagePath"])
+	}
+}

--- a/cmd/galaxio/generate_swagger_test.go
+++ b/cmd/galaxio/generate_swagger_test.go
@@ -368,7 +368,7 @@ func TestGenerateSwaggerOverwriteReplacesExistingFile(t *testing.T) {
 	if stderr != "" {
 		t.Fatalf("expected empty stderr, got %q", stderr)
 	}
-	if !strings.Contains(stdout, "overwritten: 8") {
+	if !strings.Contains(stdout, "skipped: 6") || !strings.Contains(stdout, "overwritten: 2") {
 		t.Fatalf("expected overwrite summary, got %q", stdout)
 	}
 

--- a/cmd/galaxio/generate_swagger_test.go
+++ b/cmd/galaxio/generate_swagger_test.go
@@ -329,8 +329,11 @@ func TestGenerateSwaggerSkipLeavesOriginalUntouched(t *testing.T) {
 	if code != exitOK {
 		t.Fatalf("expected exit code %d, got %d, stderr %q", exitOK, code, stderr)
 	}
-	if stderr != "" {
-		t.Fatalf("expected empty stderr, got %q", stderr)
+	if !strings.Contains(stderr, "warning: skipped existing file") {
+		t.Fatalf("expected skip warning in stderr, got %q", stderr)
+	}
+	if !strings.Contains(stderr, filepath.ToSlash(target)) && !strings.Contains(stderr, target) {
+		t.Fatalf("expected skipped file path in stderr, got %q", stderr)
 	}
 	if !strings.Contains(stdout, "skipped: 8") {
 		t.Fatalf("expected skip summary, got %q", stdout)

--- a/cmd/galaxio/generate_swagger_test.go
+++ b/cmd/galaxio/generate_swagger_test.go
@@ -1,0 +1,583 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/galax-io/galaxio-cli/internal/featureflags"
+)
+
+func TestGenerateCommandPrintsHelpWhenEnabled(t *testing.T) {
+	t.Setenv(featureflags.Generate.EnvVar, "true")
+
+	code, stdout, stderr := runCLI("generate")
+
+	if code != exitOK {
+		t.Fatalf("expected exit code %d, got %d", exitOK, code)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	for _, want := range []string{"Generate Gatling load-test source files", "swagger", "har", "postman", "--from", "--template", "--dest", "--package", "--if-exists"} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("expected help output to contain %q, got %q", want, stdout)
+		}
+	}
+}
+
+func TestGenerateSwaggerWritesFilesAndPrintsSummary(t *testing.T) {
+	t.Setenv(featureflags.Generate.EnvVar, "true")
+
+	dest := t.TempDir()
+	source := filepath.Join("..", "..", "internal", "codegen", "testdata", "petstore-swagger2.yaml")
+
+	code, stdout, stderr := runCLI(
+		"generate",
+		"swagger",
+		"--from", source,
+		"--template", "scala-sbt",
+		"--dest", dest,
+		"--package", "org.example.performance",
+	)
+
+	if code != exitOK {
+		t.Fatalf("expected exit code %d, got %d, stderr %q", exitOK, code, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, "Generated 4 action files, 3 scenario files, 1 body files") {
+		t.Fatalf("expected summary output, got %q", stdout)
+	}
+	if !strings.Contains(stdout, "Files written: 8, skipped: 0, conflicts: 0, overwritten: 0") {
+		t.Fatalf("expected conflict summary output, got %q", stdout)
+	}
+
+	for _, file := range []string{
+		"cases/AuthActions.scala",
+		"cases/PetsActions.scala",
+		"cases/OrdersActions.scala",
+		"cases/StatusActions.scala",
+		"scenarios/PetsScenario.scala",
+		"scenarios/OrdersScenario.scala",
+		"scenarios/StatusScenario.scala",
+		"resources/bodies/createPet.json",
+	} {
+		if _, err := os.Stat(filepath.Join(dest, file)); err != nil {
+			t.Fatalf("expected generated file %s: %v", file, err)
+		}
+	}
+
+	petsActions, err := os.ReadFile(filepath.Join(dest, "cases", "PetsActions.scala"))
+	if err != nil {
+		t.Fatalf("read generated actions: %v", err)
+	}
+	if !strings.Contains(string(petsActions), `package org.example.performance.cases`) {
+		t.Fatalf("expected package declaration in actions file, got %q", petsActions)
+	}
+	if !strings.Contains(string(petsActions), `.body(ElFileBody("bodies/createPet.json")).asJson`) {
+		t.Fatalf("expected body reference in actions file, got %q", petsActions)
+	}
+}
+
+func TestGenerateSwaggerSupportsJSONOutput(t *testing.T) {
+	t.Setenv(featureflags.Generate.EnvVar, "true")
+
+	dest := t.TempDir()
+	source := filepath.Join("..", "..", "internal", "codegen", "testdata", "petstore-swagger2.yaml")
+
+	code, stdout, stderr := runCLI(
+		"generate",
+		"swagger",
+		"--from", source,
+		"--dest", dest,
+		"--output", "json",
+	)
+
+	if code != exitOK {
+		t.Fatalf("expected exit code %d, got %d, stderr %q", exitOK, code, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var result generateSwaggerOutput
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("decode json output: %v; output %q", err, stdout)
+	}
+	if result.Template != "scala-sbt" {
+		t.Fatalf("expected template scala-sbt, got %q", result.Template)
+	}
+	if result.IfExists != "suffix" {
+		t.Fatalf("expected ifExists suffix, got %q", result.IfExists)
+	}
+	if result.Actions != 4 || result.Scenarios != 3 || result.BodyFiles != 1 {
+		t.Fatalf("unexpected counts: %#v", result)
+	}
+	if result.FilesWritten != 8 {
+		t.Fatalf("expected 8 files written, got %d", result.FilesWritten)
+	}
+	if result.FilesSkipped != 0 || result.FilesConflicted != 0 || result.FilesOverwritten != 0 {
+		t.Fatalf("unexpected conflict stats: %#v", result)
+	}
+}
+
+func TestGenerateSwaggerSupportsOpenAPI3Input(t *testing.T) {
+	t.Setenv(featureflags.Generate.EnvVar, "true")
+
+	dest := t.TempDir()
+	source := filepath.Join("..", "..", "internal", "codegen", "testdata", "petstore-openapi3.yaml")
+
+	code, stdout, stderr := runCLI(
+		"generate",
+		"swagger",
+		"--from", source,
+		"--template", "scala-sbt",
+		"--dest", dest,
+		"--package", "org.example.oas3",
+	)
+
+	if code != exitOK {
+		t.Fatalf("expected exit code %d, got %d, stderr %q", exitOK, code, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, "Generated") {
+		t.Fatalf("expected generation summary, got %q", stdout)
+	}
+
+	for _, file := range []string{
+		"cases/AuthActions.scala",
+		"cases/PetsActions.scala",
+		"scenarios/PetsScenario.scala",
+		"resources/bodies/createPet.json",
+	} {
+		if _, err := os.Stat(filepath.Join(dest, file)); err != nil {
+			t.Fatalf("expected generated file %s: %v", file, err)
+		}
+	}
+
+	petsActions, err := os.ReadFile(filepath.Join(dest, "cases", "PetsActions.scala"))
+	if err != nil {
+		t.Fatalf("read generated actions: %v", err)
+	}
+	if !strings.Contains(string(petsActions), `package org.example.oas3.cases`) {
+		t.Fatalf("expected package declaration in actions file, got %q", petsActions)
+	}
+	if !strings.Contains(string(petsActions), `.body(ElFileBody("bodies/createPet.json")).asJson`) {
+		t.Fatalf("expected body reference in actions file, got %q", petsActions)
+	}
+}
+
+func TestGenerateSwaggerRejectsMissingSourceFile(t *testing.T) {
+	t.Setenv(featureflags.Generate.EnvVar, "true")
+
+	code, stdout, stderr := runCLI("generate", "swagger", "--from", filepath.Join(t.TempDir(), "missing.yaml"))
+
+	if code != exitRuntime {
+		t.Fatalf("expected exit code %d, got %d", exitRuntime, code)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	for _, want := range []string{"read swagger input", "no such file"} {
+		if !strings.Contains(stderr, want) {
+			t.Fatalf("expected error to contain %q, got %q", want, stderr)
+		}
+	}
+}
+
+func TestGenerateSwaggerRejectsInvalidSwagger(t *testing.T) {
+	t.Setenv(featureflags.Generate.EnvVar, "true")
+
+	source := filepath.Join(t.TempDir(), "invalid.yaml")
+	if err := os.WriteFile(source, []byte("swagger: ["), 0o644); err != nil {
+		t.Fatalf("write invalid swagger: %v", err)
+	}
+
+	code, stdout, stderr := runCLI("generate", "swagger", "--from", source)
+
+	if code != exitRuntime {
+		t.Fatalf("expected exit code %d, got %d", exitRuntime, code)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "parse swagger input") {
+		t.Fatalf("expected parse error, got %q", stderr)
+	}
+}
+
+func TestGenerateSwaggerRejectsUnknownTemplate(t *testing.T) {
+	t.Setenv(featureflags.Generate.EnvVar, "true")
+
+	source := filepath.Join("..", "..", "internal", "codegen", "testdata", "petstore-swagger2.yaml")
+	code, stdout, stderr := runCLI("generate", "swagger", "--from", source, "--template", "java-gradle")
+
+	if code != exitUsage {
+		t.Fatalf("expected exit code %d, got %d", exitUsage, code)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, `unknown generate template "java-gradle"`) {
+		t.Fatalf("expected unknown template error, got %q", stderr)
+	}
+}
+
+func TestGenerateSwaggerRequiresFromFlag(t *testing.T) {
+	t.Setenv(featureflags.Generate.EnvVar, "true")
+
+	code, stdout, stderr := runCLI("generate", "swagger")
+
+	if code != exitUsage {
+		t.Fatalf("expected exit code %d, got %d", exitUsage, code)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, `required flag(s) "from" not set`) {
+		t.Fatalf("expected missing flag error, got %q", stderr)
+	}
+}
+
+func TestGenerateSwaggerSuffixWritesGeneratedSiblingOnSecondRun(t *testing.T) {
+	t.Setenv(featureflags.Generate.EnvVar, "true")
+
+	dest := t.TempDir()
+	source := filepath.Join("..", "..", "internal", "codegen", "testdata", "petstore-swagger2.yaml")
+
+	firstCode, _, firstStderr := runCLI("generate", "swagger", "--from", source, "--dest", dest)
+	if firstCode != exitOK || firstStderr != "" {
+		t.Fatalf("first generation failed: code=%d stderr=%q", firstCode, firstStderr)
+	}
+
+	code, stdout, stderr := runCLI("generate", "swagger", "--from", source, "--dest", dest, "--if-exists", "suffix")
+	if code != exitOK {
+		t.Fatalf("expected exit code %d, got %d, stderr %q", exitOK, code, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, "Files written: 8, skipped: 0, conflicts: 0, overwritten: 0") {
+		t.Fatalf("expected suffix summary, got %q", stdout)
+	}
+	if _, err := os.Stat(filepath.Join(dest, "cases", "PetsActions.generated.scala")); err != nil {
+		t.Fatalf("expected generated sibling file: %v", err)
+	}
+}
+
+func TestGenerateSwaggerMergeWritesConflictMarkers(t *testing.T) {
+	t.Setenv(featureflags.Generate.EnvVar, "true")
+
+	dest := t.TempDir()
+	source := filepath.Join("..", "..", "internal", "codegen", "testdata", "petstore-swagger2.yaml")
+
+	firstCode, _, firstStderr := runCLI("generate", "swagger", "--from", source, "--dest", dest)
+	if firstCode != exitOK || firstStderr != "" {
+		t.Fatalf("first generation failed: code=%d stderr=%q", firstCode, firstStderr)
+	}
+
+	target := filepath.Join(dest, "cases", "PetsActions.scala")
+	if err := os.WriteFile(target, []byte("existing"), 0o644); err != nil {
+		t.Fatalf("write existing file: %v", err)
+	}
+
+	code, stdout, stderr := runCLI("generate", "swagger", "--from", source, "--dest", dest, "--if-exists", "merge")
+	if code != exitOK {
+		t.Fatalf("expected exit code %d, got %d, stderr %q", exitOK, code, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, "conflicts: 8") {
+		t.Fatalf("expected merge conflict summary, got %q", stdout)
+	}
+
+	payload, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read merged file: %v", err)
+	}
+	for _, want := range []string{"<<<< generated", "====", ">>>> existing"} {
+		if !strings.Contains(string(payload), want) {
+			t.Fatalf("expected merged file to contain %q, got %q", want, payload)
+		}
+	}
+}
+
+func TestGenerateSwaggerSkipLeavesOriginalUntouched(t *testing.T) {
+	t.Setenv(featureflags.Generate.EnvVar, "true")
+
+	dest := t.TempDir()
+	source := filepath.Join("..", "..", "internal", "codegen", "testdata", "petstore-swagger2.yaml")
+
+	firstCode, _, firstStderr := runCLI("generate", "swagger", "--from", source, "--dest", dest)
+	if firstCode != exitOK || firstStderr != "" {
+		t.Fatalf("first generation failed: code=%d stderr=%q", firstCode, firstStderr)
+	}
+
+	target := filepath.Join(dest, "cases", "PetsActions.scala")
+	if err := os.WriteFile(target, []byte("keep-me"), 0o644); err != nil {
+		t.Fatalf("write existing file: %v", err)
+	}
+
+	code, stdout, stderr := runCLI("generate", "swagger", "--from", source, "--dest", dest, "--if-exists", "skip")
+	if code != exitOK {
+		t.Fatalf("expected exit code %d, got %d, stderr %q", exitOK, code, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, "skipped: 8") {
+		t.Fatalf("expected skip summary, got %q", stdout)
+	}
+
+	payload, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read skipped file: %v", err)
+	}
+	if string(payload) != "keep-me" {
+		t.Fatalf("expected original file untouched, got %q", payload)
+	}
+}
+
+func TestGenerateSwaggerOverwriteReplacesExistingFile(t *testing.T) {
+	t.Setenv(featureflags.Generate.EnvVar, "true")
+
+	dest := t.TempDir()
+	source := filepath.Join("..", "..", "internal", "codegen", "testdata", "petstore-swagger2.yaml")
+
+	firstCode, _, firstStderr := runCLI("generate", "swagger", "--from", source, "--dest", dest)
+	if firstCode != exitOK || firstStderr != "" {
+		t.Fatalf("first generation failed: code=%d stderr=%q", firstCode, firstStderr)
+	}
+
+	target := filepath.Join(dest, "cases", "PetsActions.scala")
+	if err := os.WriteFile(target, []byte("old"), 0o644); err != nil {
+		t.Fatalf("write existing file: %v", err)
+	}
+
+	code, stdout, stderr := runCLI("generate", "swagger", "--from", source, "--dest", dest, "--if-exists", "overwrite")
+	if code != exitOK {
+		t.Fatalf("expected exit code %d, got %d, stderr %q", exitOK, code, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, "overwritten: 8") {
+		t.Fatalf("expected overwrite summary, got %q", stdout)
+	}
+
+	payload, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read overwritten file: %v", err)
+	}
+	if strings.Contains(string(payload), "old") {
+		t.Fatalf("expected overwritten file content, got %q", payload)
+	}
+}
+
+func TestGenerateSwaggerRejectsUnknownIfExistsStrategy(t *testing.T) {
+	t.Setenv(featureflags.Generate.EnvVar, "true")
+
+	source := filepath.Join("..", "..", "internal", "codegen", "testdata", "petstore-swagger2.yaml")
+	code, stdout, stderr := runCLI("generate", "swagger", "--from", source, "--if-exists", "explode")
+
+	if code != exitUsage {
+		t.Fatalf("expected exit code %d, got %d", exitUsage, code)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, `unknown if-exists strategy "explode"`) {
+		t.Fatalf("expected if-exists error, got %q", stderr)
+	}
+}
+
+func TestGenerateSwaggerInitRendersProjectAndOverlay(t *testing.T) {
+	t.Setenv(featureflags.Generate.EnvVar, "true")
+
+	registryRoot := writeGenerateInitTemplateCatalogFixture(t)
+	dest := t.TempDir()
+	source := filepath.Join("..", "..", "internal", "codegen", "testdata", "petstore-swagger2.yaml")
+
+	code, stdout, stderr := runCLI(
+		"generate",
+		"swagger",
+		"--from", source,
+		"--dest", dest,
+		"--init",
+		"--registry", "local:"+registryRoot,
+		"--set", "Name=orders-api",
+	)
+
+	if code != exitOK {
+		t.Fatalf("expected exit code %d, got %d, stderr %q", exitOK, code, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	for _, want := range []string{
+		"Generated 4 action files, 3 scenario files, 1 body files",
+		"Files written: 11, skipped: 0, conflicts: 0, overwritten: 0",
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("expected init summary to contain %q, got %q", want, stdout)
+		}
+	}
+
+	for _, file := range []string{
+		"build.sbt",
+		"src/test/resources/gatling.conf",
+		"src/test/scala/com/example/perf/ordersapi/Debug.scala",
+		"src/test/scala/com/example/perf/ordersapi/cases/PetsActions.scala",
+		"src/test/scala/com/example/perf/ordersapi/scenarios/PetsScenario.scala",
+		"src/test/resources/bodies/createPet.json",
+	} {
+		if _, err := os.Stat(filepath.Join(dest, file)); err != nil {
+			t.Fatalf("expected init output file %s: %v", file, err)
+		}
+	}
+
+	payload, err := os.ReadFile(filepath.Join(dest, "src", "test", "scala", "com", "example", "perf", "ordersapi", "cases", "PetsActions.scala"))
+	if err != nil {
+		t.Fatalf("read overlaid actions file: %v", err)
+	}
+	if !strings.Contains(string(payload), "package com.example.perf.ordersapi.cases") {
+		t.Fatalf("expected init overlay package, got %q", payload)
+	}
+}
+
+func TestGenerateSwaggerInitRejectsExistingDestinationWithoutExplicitIfExists(t *testing.T) {
+	t.Setenv(featureflags.Generate.EnvVar, "true")
+
+	registryRoot := writeGenerateInitTemplateCatalogFixture(t)
+	dest := t.TempDir()
+	writeGenerateFile(t, dest, "existing.txt", "keep\n")
+	source := filepath.Join("..", "..", "internal", "codegen", "testdata", "petstore-swagger2.yaml")
+
+	code, stdout, stderr := runCLI(
+		"generate",
+		"swagger",
+		"--from", source,
+		"--dest", dest,
+		"--init",
+		"--registry", "local:"+registryRoot,
+	)
+
+	if code != exitRuntime {
+		t.Fatalf("expected exit code %d, got %d", exitRuntime, code)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "already contains files; rerun with --if-exists") {
+		t.Fatalf("expected existing destination error, got %q", stderr)
+	}
+}
+
+func TestGenerateSwaggerInitAllowsExistingDestinationWithExplicitIfExists(t *testing.T) {
+	t.Setenv(featureflags.Generate.EnvVar, "true")
+
+	registryRoot := writeGenerateInitTemplateCatalogFixture(t)
+	dest := t.TempDir()
+	writeGenerateFile(t, dest, "build.sbt", "old\n")
+	source := filepath.Join("..", "..", "internal", "codegen", "testdata", "petstore-swagger2.yaml")
+
+	code, stdout, stderr := runCLI(
+		"generate",
+		"swagger",
+		"--from", source,
+		"--dest", dest,
+		"--init",
+		"--registry", "local:"+registryRoot,
+		"--if-exists", "overwrite",
+	)
+
+	if code != exitOK {
+		t.Fatalf("expected exit code %d, got %d, stderr %q", exitOK, code, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, "overwritten:") {
+		t.Fatalf("expected overwrite summary, got %q", stdout)
+	}
+
+	payload, err := os.ReadFile(filepath.Join(dest, "build.sbt"))
+	if err != nil {
+		t.Fatalf("read scaffold file: %v", err)
+	}
+	if strings.Contains(string(payload), "old") {
+		t.Fatalf("expected scaffold file to be overwritten, got %q", payload)
+	}
+}
+
+func writeGenerateInitTemplateCatalogFixture(t *testing.T) string {
+	t.Helper()
+
+	packRoot := t.TempDir()
+	writeGenerateFile(t, packRoot, "galaxio-pack.yaml", `apiVersion: galaxio.io/v1
+kind: TemplatePack
+name: gatling
+version: 0.1.0
+templates:
+  - name: scala-sbt
+    version: 1.0.0
+    path: scala-sbt
+`)
+	writeGenerateFile(t, packRoot, "scala-sbt/galaxio-template.yaml", `apiVersion: galaxio.io/v1
+kind: Template
+name: scala-sbt
+engine: go-template
+inputs:
+  Name:
+    type: string
+    default: myservice
+  NameWord:
+    type: string
+    default: myservice
+  Package:
+    type: string
+    default: org.galaxio.performance
+  PackagePath:
+    type: string
+    default: org/galaxio/performance
+files:
+  - from: files
+    to: .
+`)
+	writeGenerateFile(t, packRoot, "scala-sbt/files/build.sbt", `name := "{{ .Name }}"
+`)
+	writeGenerateFile(t, packRoot, "scala-sbt/files/src/test/resources/gatling.conf", "gatling {}\n")
+	writeGenerateFile(t, packRoot, "scala-sbt/files/src/test/scala/{{ .PackagePath }}/{{ .NameWord }}/Debug.scala", `package {{ .Package }}.{{ .NameWord }}
+
+object Debug
+`)
+
+	registryRoot := t.TempDir()
+	writeGenerateFile(t, registryRoot, "galaxio-registry.yaml", `apiVersion: galaxio.io/v1
+kind: TemplateRegistry
+packs:
+  - name: gatling
+    source: local:`+packRoot+`
+`)
+
+	return registryRoot
+}
+
+func writeGenerateFile(t *testing.T, root string, name string, content string) {
+	t.Helper()
+
+	path := filepath.Join(root, name)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("create dir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+}

--- a/cmd/galaxio/generate_swagger_test.go
+++ b/cmd/galaxio/generate_swagger_test.go
@@ -368,7 +368,7 @@ func TestGenerateSwaggerOverwriteReplacesExistingFile(t *testing.T) {
 	if stderr != "" {
 		t.Fatalf("expected empty stderr, got %q", stderr)
 	}
-	if !strings.Contains(stdout, "skipped: 6") || !strings.Contains(stdout, "overwritten: 2") {
+	if !strings.Contains(stdout, "skipped: ") || !strings.Contains(stdout, "overwritten: ") || strings.Contains(stdout, "overwritten: 8") {
 		t.Fatalf("expected overwrite summary, got %q", stdout)
 	}
 

--- a/cmd/galaxio/root.go
+++ b/cmd/galaxio/root.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/galax-io/galaxio-cli/internal/featureflags"
 	"github.com/spf13/cobra"
@@ -96,6 +97,7 @@ func execute(args []string, stdout io.Writer, stderr io.Writer) int {
 	if err == nil {
 		err = cmd.Execute()
 	}
+	err = normalizeCLIError(err)
 	if err != nil {
 		_, _ = fmt.Fprintf(stderr, "Error: %s\n", err)
 	}
@@ -105,4 +107,14 @@ func execute(args []string, stdout io.Writer, stderr io.Writer) int {
 
 func buildVersionString() string {
 	return versionInfo().CleanVersion()
+}
+
+func normalizeCLIError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if strings.Contains(err.Error(), "unknown command") {
+		return UsageError{Err: err}
+	}
+	return err
 }

--- a/cmd/galaxio/root_test.go
+++ b/cmd/galaxio/root_test.go
@@ -618,7 +618,7 @@ func TestExitCodeMapping(t *testing.T) {
 		{name: "ok", err: nil, want: exitOK},
 		{name: "usage", err: UsageError{Err: errors.New("bad args")}, want: exitUsage},
 		{name: "runtime", err: RuntimeError{Err: errors.New("boom")}, want: exitRuntime},
-		{name: "unknown defaults to usage", err: errors.New("unknown command"), want: exitUsage},
+		{name: "unknown defaults to runtime", err: errors.New("unknown command"), want: exitRuntime},
 	}
 
 	for _, tt := range tests {

--- a/cmd/galaxio/root_test.go
+++ b/cmd/galaxio/root_test.go
@@ -81,30 +81,32 @@ func TestGenerateCommandIsRegisteredWhenEnabled(t *testing.T) {
 
 	code, stdout, stderr := runCLI("generate")
 
-	if code != exitRuntime {
-		t.Fatalf("expected exit code %d, got %d", exitRuntime, code)
+	if code != exitOK {
+		t.Fatalf("expected exit code %d, got %d", exitOK, code)
 	}
-	if stdout != "" {
-		t.Fatalf("expected empty stdout, got %q", stdout)
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
 	}
-	if want := "not implemented yet"; !strings.Contains(stderr, want) {
-		t.Fatalf("expected generate placeholder error, got %q", stderr)
+	if want := "Generate Gatling load-test source files"; !strings.Contains(stdout, want) {
+		t.Fatalf("expected generate help output, got %q", stdout)
 	}
 }
 
-func TestGenerateSubcommandsReachPlaceholderWhenEnabled(t *testing.T) {
+func TestGenerateSubcommandsAreShownWhenEnabled(t *testing.T) {
 	t.Setenv(featureflags.Generate.EnvVar, "true")
 
-	code, stdout, stderr := runCLI("generate", "swagger")
+	code, stdout, stderr := runCLI("generate", "--help")
 
-	if code != exitRuntime {
-		t.Fatalf("expected exit code %d, got %d", exitRuntime, code)
+	if code != exitOK {
+		t.Fatalf("expected exit code %d, got %d", exitOK, code)
 	}
-	if stdout != "" {
-		t.Fatalf("expected empty stdout, got %q", stdout)
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
 	}
-	if want := "not implemented yet"; !strings.Contains(stderr, want) {
-		t.Fatalf("expected generate placeholder error, got %q", stderr)
+	for _, want := range []string{"swagger", "har", "postman", "--from", "--template", "--dest", "--package"} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("expected generate help to contain %q, got %q", want, stdout)
+		}
 	}
 }
 

--- a/internal/codegen/conflict.go
+++ b/internal/codegen/conflict.go
@@ -19,11 +19,20 @@ const (
 	IfExistsOverwrite = "overwrite"
 )
 
+type ConflictStatus string
+
+const (
+	ConflictStatusWritten     ConflictStatus = "written"
+	ConflictStatusSkipped     ConflictStatus = "skipped"
+	ConflictStatusConflict    ConflictStatus = "conflict"
+	ConflictStatusOverwritten ConflictStatus = "overwritten"
+)
+
 // ConflictResult reports how one file write was resolved.
 type ConflictResult struct {
 	Path        string
 	WrittenPath string
-	Status      string
+	Status      ConflictStatus
 }
 
 // ValidateIfExistsStrategy validates supported conflict strategies.
@@ -54,7 +63,7 @@ func WriteFileWithStrategy(targetPath string, content []byte, strategy string) (
 		if err := os.WriteFile(targetPath, content, 0o644); err != nil {
 			return ConflictResult{}, err
 		}
-		return ConflictResult{Path: targetPath, WrittenPath: targetPath, Status: "written"}, nil
+		return ConflictResult{Path: targetPath, WrittenPath: targetPath, Status: ConflictStatusWritten}, nil
 	}
 
 	switch strategy {
@@ -63,23 +72,23 @@ func WriteFileWithStrategy(targetPath string, content []byte, strategy string) (
 		if err := os.WriteFile(generatedPath, content, 0o644); err != nil {
 			return ConflictResult{}, err
 		}
-		return ConflictResult{Path: targetPath, WrittenPath: generatedPath, Status: "written"}, nil
+		return ConflictResult{Path: targetPath, WrittenPath: generatedPath, Status: ConflictStatusWritten}, nil
 	case IfExistsMerge:
 		merged := mergeConflictContent(content, existing)
 		if err := os.WriteFile(targetPath, merged, 0o644); err != nil {
 			return ConflictResult{}, err
 		}
-		return ConflictResult{Path: targetPath, WrittenPath: targetPath, Status: "conflict"}, nil
+		return ConflictResult{Path: targetPath, WrittenPath: targetPath, Status: ConflictStatusConflict}, nil
 	case IfExistsSkip:
-		return ConflictResult{Path: targetPath, WrittenPath: targetPath, Status: "skipped"}, nil
+		return ConflictResult{Path: targetPath, WrittenPath: targetPath, Status: ConflictStatusSkipped}, nil
 	case IfExistsOverwrite:
 		if bytes.Equal(existing, content) {
-			return ConflictResult{Path: targetPath, WrittenPath: targetPath, Status: "overwritten"}, nil
+			return ConflictResult{Path: targetPath, WrittenPath: targetPath, Status: ConflictStatusSkipped}, nil
 		}
 		if err := os.WriteFile(targetPath, content, 0o644); err != nil {
 			return ConflictResult{}, err
 		}
-		return ConflictResult{Path: targetPath, WrittenPath: targetPath, Status: "overwritten"}, nil
+		return ConflictResult{Path: targetPath, WrittenPath: targetPath, Status: ConflictStatusOverwritten}, nil
 	default:
 		return ConflictResult{}, fmt.Errorf("unknown if-exists strategy %q", strategy)
 	}

--- a/internal/codegen/conflict.go
+++ b/internal/codegen/conflict.go
@@ -1,0 +1,111 @@
+package codegen
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	// IfExistsSuffix writes a sibling *.generated file when the target already exists.
+	IfExistsSuffix = "suffix"
+	// IfExistsMerge writes conflict markers into the existing target file.
+	IfExistsMerge = "merge"
+	// IfExistsSkip leaves the existing target untouched.
+	IfExistsSkip = "skip"
+	// IfExistsOverwrite replaces the existing target file completely.
+	IfExistsOverwrite = "overwrite"
+)
+
+// ConflictResult reports how one file write was resolved.
+type ConflictResult struct {
+	Path        string
+	WrittenPath string
+	Status      string
+}
+
+// ValidateIfExistsStrategy validates supported conflict strategies.
+func ValidateIfExistsStrategy(strategy string) error {
+	switch strings.TrimSpace(strategy) {
+	case IfExistsSuffix, IfExistsMerge, IfExistsSkip, IfExistsOverwrite:
+		return nil
+	default:
+		return fmt.Errorf("unknown if-exists strategy %q", strategy)
+	}
+}
+
+// WriteFileWithStrategy writes content to targetPath honoring the selected conflict strategy.
+func WriteFileWithStrategy(targetPath string, content []byte, strategy string) (ConflictResult, error) {
+	if err := ValidateIfExistsStrategy(strategy); err != nil {
+		return ConflictResult{}, err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+		return ConflictResult{}, err
+	}
+
+	existing, err := os.ReadFile(targetPath)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return ConflictResult{}, err
+		}
+		if err := os.WriteFile(targetPath, content, 0o644); err != nil {
+			return ConflictResult{}, err
+		}
+		return ConflictResult{Path: targetPath, WrittenPath: targetPath, Status: "written"}, nil
+	}
+
+	switch strategy {
+	case IfExistsSuffix:
+		generatedPath := generatedSiblingPath(targetPath)
+		if err := os.WriteFile(generatedPath, content, 0o644); err != nil {
+			return ConflictResult{}, err
+		}
+		return ConflictResult{Path: targetPath, WrittenPath: generatedPath, Status: "written"}, nil
+	case IfExistsMerge:
+		merged := mergeConflictContent(content, existing)
+		if err := os.WriteFile(targetPath, merged, 0o644); err != nil {
+			return ConflictResult{}, err
+		}
+		return ConflictResult{Path: targetPath, WrittenPath: targetPath, Status: "conflict"}, nil
+	case IfExistsSkip:
+		return ConflictResult{Path: targetPath, WrittenPath: targetPath, Status: "skipped"}, nil
+	case IfExistsOverwrite:
+		if bytes.Equal(existing, content) {
+			return ConflictResult{Path: targetPath, WrittenPath: targetPath, Status: "overwritten"}, nil
+		}
+		if err := os.WriteFile(targetPath, content, 0o644); err != nil {
+			return ConflictResult{}, err
+		}
+		return ConflictResult{Path: targetPath, WrittenPath: targetPath, Status: "overwritten"}, nil
+	default:
+		return ConflictResult{}, fmt.Errorf("unknown if-exists strategy %q", strategy)
+	}
+}
+
+func generatedSiblingPath(targetPath string) string {
+	ext := filepath.Ext(targetPath)
+	base := strings.TrimSuffix(targetPath, ext)
+	if ext == "" {
+		return base + ".generated"
+	}
+	return base + ".generated" + ext
+}
+
+func mergeConflictContent(generated []byte, existing []byte) []byte {
+	var builder strings.Builder
+	builder.WriteString("<<<< generated\n")
+	builder.Write(generated)
+	if len(generated) == 0 || generated[len(generated)-1] != '\n' {
+		builder.WriteByte('\n')
+	}
+	builder.WriteString("====\n")
+	builder.Write(existing)
+	if len(existing) == 0 || existing[len(existing)-1] != '\n' {
+		builder.WriteByte('\n')
+	}
+	builder.WriteString(">>>> existing\n")
+	return []byte(builder.String())
+}

--- a/internal/codegen/conflict_test.go
+++ b/internal/codegen/conflict_test.go
@@ -1,0 +1,142 @@
+package codegen
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestValidateIfExistsStrategy(t *testing.T) {
+	t.Parallel()
+
+	for _, strategy := range []string{IfExistsSuffix, IfExistsMerge, IfExistsSkip, IfExistsOverwrite} {
+		if err := ValidateIfExistsStrategy(strategy); err != nil {
+			t.Fatalf("ValidateIfExistsStrategy(%q) error = %v", strategy, err)
+		}
+	}
+
+	if err := ValidateIfExistsStrategy("bad"); err == nil {
+		t.Fatal("expected invalid strategy to fail")
+	}
+}
+
+func TestWriteFileWithStrategyWritesNewFile(t *testing.T) {
+	t.Parallel()
+
+	target := filepath.Join(t.TempDir(), "cases", "PetsActions.scala")
+	result, err := WriteFileWithStrategy(target, []byte("generated"), IfExistsSuffix)
+	if err != nil {
+		t.Fatalf("WriteFileWithStrategy() error = %v", err)
+	}
+	if result.Status != "written" {
+		t.Fatalf("expected written status, got %#v", result)
+	}
+	assertFileEquals(t, target, "generated")
+}
+
+func TestWriteFileWithStrategySuffixCreatesGeneratedSibling(t *testing.T) {
+	t.Parallel()
+
+	target := filepath.Join(t.TempDir(), "cases", "PetsActions.scala")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(target, []byte("existing"), 0o644); err != nil {
+		t.Fatalf("WriteFile(existing) error = %v", err)
+	}
+
+	result, err := WriteFileWithStrategy(target, []byte("generated"), IfExistsSuffix)
+	if err != nil {
+		t.Fatalf("WriteFileWithStrategy() error = %v", err)
+	}
+	if result.WrittenPath != filepath.Join(filepath.Dir(target), "PetsActions.generated.scala") {
+		t.Fatalf("unexpected written path %#v", result)
+	}
+	assertFileEquals(t, target, "existing")
+	assertFileEquals(t, result.WrittenPath, "generated")
+}
+
+func TestWriteFileWithStrategyMergeWritesConflictMarkers(t *testing.T) {
+	t.Parallel()
+
+	target := filepath.Join(t.TempDir(), "cases", "PetsActions.scala")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(target, []byte("existing"), 0o644); err != nil {
+		t.Fatalf("WriteFile(existing) error = %v", err)
+	}
+
+	result, err := WriteFileWithStrategy(target, []byte("generated"), IfExistsMerge)
+	if err != nil {
+		t.Fatalf("WriteFileWithStrategy() error = %v", err)
+	}
+	if result.Status != "conflict" {
+		t.Fatalf("expected conflict status, got %#v", result)
+	}
+
+	payload, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	for _, want := range []string{"<<<< generated", "generated", "====", "existing", ">>>> existing"} {
+		if !strings.Contains(string(payload), want) {
+			t.Fatalf("expected merged content to contain %q, got %q", want, payload)
+		}
+	}
+}
+
+func TestWriteFileWithStrategySkipLeavesOriginalUntouched(t *testing.T) {
+	t.Parallel()
+
+	target := filepath.Join(t.TempDir(), "cases", "PetsActions.scala")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(target, []byte("existing"), 0o644); err != nil {
+		t.Fatalf("WriteFile(existing) error = %v", err)
+	}
+
+	result, err := WriteFileWithStrategy(target, []byte("generated"), IfExistsSkip)
+	if err != nil {
+		t.Fatalf("WriteFileWithStrategy() error = %v", err)
+	}
+	if result.Status != "skipped" {
+		t.Fatalf("expected skipped status, got %#v", result)
+	}
+	assertFileEquals(t, target, "existing")
+}
+
+func TestWriteFileWithStrategyOverwriteReplacesExistingFile(t *testing.T) {
+	t.Parallel()
+
+	target := filepath.Join(t.TempDir(), "cases", "PetsActions.scala")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(target, []byte("existing"), 0o644); err != nil {
+		t.Fatalf("WriteFile(existing) error = %v", err)
+	}
+
+	result, err := WriteFileWithStrategy(target, []byte("generated"), IfExistsOverwrite)
+	if err != nil {
+		t.Fatalf("WriteFileWithStrategy() error = %v", err)
+	}
+	if result.Status != "overwritten" {
+		t.Fatalf("expected overwritten status, got %#v", result)
+	}
+	assertFileEquals(t, target, "generated")
+}
+
+func assertFileEquals(t *testing.T, path string, want string) {
+	t.Helper()
+
+	payload, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", path, err)
+	}
+	if string(payload) != want {
+		t.Fatalf("expected %q, got %q", want, payload)
+	}
+}

--- a/internal/codegen/conflict_test.go
+++ b/internal/codegen/conflict_test.go
@@ -29,7 +29,7 @@ func TestWriteFileWithStrategyWritesNewFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("WriteFileWithStrategy() error = %v", err)
 	}
-	if result.Status != "written" {
+	if result.Status != ConflictStatusWritten {
 		t.Fatalf("expected written status, got %#v", result)
 	}
 	assertFileEquals(t, target, "generated")
@@ -72,7 +72,7 @@ func TestWriteFileWithStrategyMergeWritesConflictMarkers(t *testing.T) {
 	if err != nil {
 		t.Fatalf("WriteFileWithStrategy() error = %v", err)
 	}
-	if result.Status != "conflict" {
+	if result.Status != ConflictStatusConflict {
 		t.Fatalf("expected conflict status, got %#v", result)
 	}
 
@@ -102,7 +102,7 @@ func TestWriteFileWithStrategySkipLeavesOriginalUntouched(t *testing.T) {
 	if err != nil {
 		t.Fatalf("WriteFileWithStrategy() error = %v", err)
 	}
-	if result.Status != "skipped" {
+	if result.Status != ConflictStatusSkipped {
 		t.Fatalf("expected skipped status, got %#v", result)
 	}
 	assertFileEquals(t, target, "existing")
@@ -123,10 +123,31 @@ func TestWriteFileWithStrategyOverwriteReplacesExistingFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("WriteFileWithStrategy() error = %v", err)
 	}
-	if result.Status != "overwritten" {
+	if result.Status != ConflictStatusOverwritten {
 		t.Fatalf("expected overwritten status, got %#v", result)
 	}
 	assertFileEquals(t, target, "generated")
+}
+
+func TestWriteFileWithStrategyOverwriteSkipsIdenticalContent(t *testing.T) {
+	t.Parallel()
+
+	target := filepath.Join(t.TempDir(), "cases", "PetsActions.scala")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(target, []byte("same"), 0o644); err != nil {
+		t.Fatalf("WriteFile(existing) error = %v", err)
+	}
+
+	result, err := WriteFileWithStrategy(target, []byte("same"), IfExistsOverwrite)
+	if err != nil {
+		t.Fatalf("WriteFileWithStrategy() error = %v", err)
+	}
+	if result.Status != ConflictStatusSkipped {
+		t.Fatalf("expected skipped status for identical overwrite, got %#v", result)
+	}
+	assertFileEquals(t, target, "same")
 }
 
 func assertFileEquals(t *testing.T, path string, want string) {

--- a/internal/codegen/ir.go
+++ b/internal/codegen/ir.go
@@ -23,6 +23,7 @@ type Request struct {
 	Path      string
 	Name      string
 	Summary   string
+	Comments  []string
 	Headers   []Header
 	Params    []Param
 	Body      *BodySchema
@@ -35,6 +36,7 @@ type BodySchema struct {
 	Type     string
 	Format   string
 	Required bool
+	Raw      string
 	Fields   []BodySchema
 	Items    *BodySchema
 }

--- a/internal/codegen/naming.go
+++ b/internal/codegen/naming.go
@@ -1,0 +1,80 @@
+package codegen
+
+import (
+	"strings"
+	"unicode"
+)
+
+// LowerCamel converts human-readable identifiers into lowerCamelCase.
+func LowerCamel(value string) string {
+	words := SplitWords(value)
+	if len(words) == 0 {
+		return ""
+	}
+
+	for i := range words {
+		words[i] = strings.ToLower(words[i])
+	}
+
+	result := words[0]
+	for _, word := range words[1:] {
+		result += strings.ToUpper(word[:1]) + word[1:]
+	}
+
+	return result
+}
+
+// DeriveNameWord normalizes a name into a compact lower-case token for paths.
+func DeriveNameWord(value string) string {
+	words := SplitWords(value)
+	if len(words) == 0 {
+		return "generated"
+	}
+
+	var builder strings.Builder
+	for _, word := range words {
+		builder.WriteString(strings.ToLower(word))
+	}
+	return builder.String()
+}
+
+// SplitWords breaks identifiers like "PetAdmin", "pet-admin", or "pet_admin" into words.
+func SplitWords(value string) []string {
+	replacer := strings.NewReplacer("/", " ", "-", " ", "_", " ", ".", " ")
+	value = replacer.Replace(value)
+
+	parts := strings.FieldsFunc(value, func(r rune) bool {
+		return unicode.IsSpace(r) || unicode.IsPunct(r)
+	})
+
+	words := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if part == "" {
+			continue
+		}
+
+		var builder strings.Builder
+		runes := []rune(part)
+		for i, r := range runes {
+			if i > 0 && unicode.IsUpper(r) && (unicode.IsLower(runes[i-1]) || i+1 < len(runes) && unicode.IsLower(runes[i+1])) {
+				words = appendWord(words, builder.String())
+				builder.Reset()
+			}
+			builder.WriteRune(r)
+		}
+		words = appendWord(words, builder.String())
+	}
+
+	return words
+}
+
+func appendWord(words []string, word string) []string {
+	word = strings.TrimSpace(word)
+	if word == "" {
+		return words
+	}
+	if strings.HasPrefix(word, "{") && strings.HasSuffix(word, "}") {
+		return words
+	}
+	return append(words, word)
+}

--- a/internal/codegen/naming_test.go
+++ b/internal/codegen/naming_test.go
@@ -1,0 +1,43 @@
+package codegen
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestLowerCamel(t *testing.T) {
+	t.Parallel()
+
+	if got := LowerCamel("Pet Admin API"); got != "petAdminApi" {
+		t.Fatalf("expected petAdminApi, got %q", got)
+	}
+}
+
+func TestDeriveNameWord(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{input: "Orders API", want: "ordersapi"},
+		{input: "orders-api", want: "ordersapi"},
+		{input: "", want: "generated"},
+	}
+
+	for _, tt := range tests {
+		if got := DeriveNameWord(tt.input); got != tt.want {
+			t.Fatalf("DeriveNameWord(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestSplitWords(t *testing.T) {
+	t.Parallel()
+
+	got := SplitWords("PetAdmin/{petId}/create-order")
+	want := []string{"Pet", "Admin", "pet", "Id", "create", "order"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("SplitWords() = %#v, want %#v", got, want)
+	}
+}

--- a/internal/codegen/parser/har.go
+++ b/internal/codegen/parser/har.go
@@ -1,0 +1,392 @@
+package parser
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"path"
+	"strings"
+	"unicode"
+
+	"github.com/galax-io/galaxio-cli/internal/codegen"
+)
+
+type HARParser struct {
+	includeStatic bool
+}
+
+var _ Parser = (*HARParser)(nil)
+
+func NewHARParser(includeStatic bool) *HARParser {
+	return &HARParser{includeStatic: includeStatic}
+}
+
+func (p *HARParser) Parse(_ context.Context, data []byte) (*codegen.Spec, error) {
+	var doc harDocument
+	if err := json.Unmarshal(data, &doc); err != nil {
+		return nil, fmt.Errorf("decode har document: %w", err)
+	}
+
+	spec := &codegen.Spec{
+		Title:    strings.TrimSpace(firstHARPageTitle(doc.Log.Pages)),
+		Version:  strings.TrimSpace(doc.Log.Version),
+		BasePath: "",
+	}
+	if spec.Version == "" {
+		spec.Version = "1.2"
+	}
+	if spec.Title == "" {
+		spec.Title = "HAR Recording"
+	}
+	if len(doc.Log.Entries) == 0 {
+		return nil, fmt.Errorf("decode har document: missing log.entries")
+	}
+
+	requests := make([]codegen.Request, 0, len(doc.Log.Entries))
+	groupName := ""
+	nameCounts := make(map[string]int)
+	for _, entry := range doc.Log.Entries {
+		if !p.includeStatic && isStaticHAREntry(entry) {
+			continue
+		}
+
+		request, err := buildHARRequest(entry, nameCounts)
+		if err != nil {
+			return nil, err
+		}
+		if request.Name == "" {
+			continue
+		}
+		if groupName == "" {
+			groupName = harGroupName(entry.Request.URL)
+		}
+		requests = append(requests, request)
+	}
+
+	if groupName == "" {
+		groupName = "recording"
+	}
+	if len(requests) > 0 {
+		spec.Groups = []codegen.Group{{
+			Name:     groupName,
+			Requests: requests,
+		}}
+	}
+
+	return spec, nil
+}
+
+type harDocument struct {
+	Log harLog `json:"log"`
+}
+
+type harLog struct {
+	Version string     `json:"version"`
+	Pages   []harPage  `json:"pages"`
+	Entries []harEntry `json:"entries"`
+}
+
+type harPage struct {
+	Title string `json:"title"`
+}
+
+type harEntry struct {
+	Request  harRequest  `json:"request"`
+	Response harResponse `json:"response"`
+}
+
+type harRequest struct {
+	Method      string         `json:"method"`
+	URL         string         `json:"url"`
+	Headers     []harNameValue `json:"headers"`
+	QueryString []harNameValue `json:"queryString"`
+	Cookies     []harCookie    `json:"cookies"`
+	PostData    *harPostData   `json:"postData"`
+}
+
+type harResponse struct {
+	Status  int        `json:"status"`
+	Content harContent `json:"content"`
+}
+
+type harPostData struct {
+	MimeType string `json:"mimeType"`
+	Text     string `json:"text"`
+}
+
+type harContent struct {
+	MimeType string `json:"mimeType"`
+}
+
+type harNameValue struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+type harCookie struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+func firstHARPageTitle(pages []harPage) string {
+	for _, page := range pages {
+		if strings.TrimSpace(page.Title) != "" {
+			return page.Title
+		}
+	}
+	return ""
+}
+
+func buildHARRequest(entry harEntry, nameCounts map[string]int) (codegen.Request, error) {
+	parsedURL, err := url.Parse(entry.Request.URL)
+	if err != nil {
+		return codegen.Request{}, fmt.Errorf("parse har request url %q: %w", entry.Request.URL, err)
+	}
+
+	baseName := harRequestName(entry.Request.Method, parsedURL.Path)
+	nameCounts[baseName]++
+	requestName := baseName
+	if nameCounts[baseName] > 1 {
+		requestName = fmt.Sprintf("%s%d", baseName, nameCounts[baseName])
+	}
+
+	request := codegen.Request{
+		Method:  strings.ToUpper(entry.Request.Method),
+		Path:    parsedURL.EscapedPath(),
+		Name:    requestName,
+		Summary: strings.TrimSpace(entry.Request.Method) + " " + parsedURL.EscapedPath(),
+	}
+	if request.Path == "" {
+		request.Path = "/"
+	}
+
+	request.Headers = harHeaders(entry.Request.Headers, entry.Request.Cookies)
+	request.Params = harParams(entry.Request.QueryString)
+	if body := harBodySchema(entry.Request.PostData); body != nil {
+		request.Body = body
+	}
+	if entry.Response.Status > 0 {
+		request.Responses = []codegen.Response{{
+			StatusCode: fmt.Sprintf("%d", entry.Response.Status),
+		}}
+	}
+
+	return request, nil
+}
+
+func harHeaders(headers []harNameValue, cookies []harCookie) []codegen.Header {
+	result := make([]codegen.Header, 0, len(headers)+1)
+	seen := make(map[string]struct{})
+	for _, header := range headers {
+		name := strings.TrimSpace(header.Name)
+		value := strings.TrimSpace(header.Value)
+		if name == "" || value == "" {
+			continue
+		}
+
+		lowerName := strings.ToLower(name)
+		if _, ok := seen[lowerName]; ok {
+			continue
+		}
+		if shouldSkipHARHeader(lowerName) {
+			continue
+		}
+
+		result = append(result, codegen.Header{
+			Name:  name,
+			Value: value,
+		})
+		seen[lowerName] = struct{}{}
+	}
+
+	if cookieValue := harCookieHeader(cookies); cookieValue != "" {
+		result = append(result, codegen.Header{
+			Name:  "Cookie",
+			Value: cookieValue,
+		})
+	}
+
+	return result
+}
+
+func shouldSkipHARHeader(name string) bool {
+	switch name {
+	case "", "cookie", "content-length", "host", ":authority", ":method", ":path", ":scheme":
+		return true
+	default:
+		return false
+	}
+}
+
+func harCookieHeader(cookies []harCookie) string {
+	parts := make([]string, 0, len(cookies))
+	for _, cookie := range cookies {
+		name := strings.TrimSpace(cookie.Name)
+		if name == "" {
+			continue
+		}
+		parts = append(parts, name+"="+cookie.Value)
+	}
+	return strings.Join(parts, "; ")
+}
+
+func harParams(query []harNameValue) []codegen.Param {
+	params := make([]codegen.Param, 0, len(query))
+	for _, param := range query {
+		name := strings.TrimSpace(param.Name)
+		if name == "" {
+			continue
+		}
+		params = append(params, codegen.Param{
+			Name:     name,
+			In:       "query",
+			Type:     "string",
+			Required: true,
+		})
+	}
+	return params
+}
+
+func harBodySchema(postData *harPostData) *codegen.BodySchema {
+	if postData == nil || strings.TrimSpace(postData.Text) == "" {
+		return nil
+	}
+
+	bodyType := "string"
+	trimmed := strings.TrimSpace(postData.Text)
+	if strings.HasPrefix(trimmed, "{") {
+		bodyType = "object"
+	}
+	if strings.HasPrefix(trimmed, "[") {
+		bodyType = "array"
+	}
+
+	return &codegen.BodySchema{
+		Type:     bodyType,
+		Required: true,
+		Raw:      trimmed,
+	}
+}
+
+func isStaticHAREntry(entry harEntry) bool {
+	mimeType := strings.ToLower(strings.TrimSpace(entry.Response.Content.MimeType))
+	for _, prefix := range []string{"image/", "font/", "audio/", "video/"} {
+		if strings.HasPrefix(mimeType, prefix) {
+			return true
+		}
+	}
+	for _, exact := range []string{
+		"text/css",
+		"text/javascript",
+		"application/javascript",
+		"application/x-javascript",
+	} {
+		if mimeType == exact {
+			return true
+		}
+	}
+
+	parsedURL, err := url.Parse(entry.Request.URL)
+	if err != nil {
+		return false
+	}
+	switch strings.ToLower(path.Ext(parsedURL.Path)) {
+	case ".css", ".js", ".mjs", ".png", ".jpg", ".jpeg", ".gif", ".svg", ".webp", ".ico", ".woff", ".woff2", ".ttf", ".eot":
+		return true
+	default:
+		return false
+	}
+}
+
+func harGroupName(rawURL string) string {
+	parsedURL, err := url.Parse(rawURL)
+	if err == nil {
+		host := strings.TrimSpace(parsedURL.Hostname())
+		if host != "" {
+			return lowerCamelHAR(host)
+		}
+		if segment := firstMeaningfulHARSegment(parsedURL.Path); segment != "" {
+			return lowerCamelHAR(segment)
+		}
+	}
+	return "recording"
+}
+
+func harRequestName(method string, rawPath string) string {
+	parts := []string{strings.ToLower(strings.TrimSpace(method))}
+	parts = append(parts, meaningfulHARSegments(rawPath)...)
+	if len(parts) == 1 {
+		parts = append(parts, "request")
+	}
+	return lowerCamelHAR(strings.Join(parts, " "))
+}
+
+func firstMeaningfulHARSegment(rawPath string) string {
+	segments := meaningfulHARSegments(rawPath)
+	if len(segments) == 0 {
+		return ""
+	}
+	return segments[0]
+}
+
+func meaningfulHARSegments(rawPath string) []string {
+	pieces := strings.Split(rawPath, "/")
+	segments := make([]string, 0, len(pieces))
+	for _, piece := range pieces {
+		piece = strings.TrimSpace(piece)
+		if piece == "" {
+			continue
+		}
+		lowerPiece := strings.ToLower(piece)
+		if lowerPiece == "api" || versionSegmentPattern.MatchString(lowerPiece) || isNumericHARSegment(lowerPiece) {
+			continue
+		}
+		segments = append(segments, piece)
+	}
+	return segments
+}
+
+func isNumericHARSegment(value string) bool {
+	for _, r := range value {
+		if !unicode.IsDigit(r) {
+			return false
+		}
+	}
+	return value != ""
+}
+
+func lowerCamelHAR(value string) string {
+	words := splitHARWords(value)
+	if len(words) == 0 {
+		return ""
+	}
+
+	for i := range words {
+		words[i] = strings.ToLower(words[i])
+	}
+
+	result := words[0]
+	for _, word := range words[1:] {
+		result += strings.ToUpper(word[:1]) + word[1:]
+	}
+	return result
+}
+
+func splitHARWords(value string) []string {
+	replacer := strings.NewReplacer("/", " ", "-", " ", "_", " ", ".", " ", ":", " ")
+	value = replacer.Replace(value)
+
+	parts := strings.FieldsFunc(value, func(r rune) bool {
+		return unicode.IsSpace(r) || unicode.IsPunct(r)
+	})
+
+	words := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			words = append(words, part)
+		}
+	}
+	return words
+}

--- a/internal/codegen/parser/har_test.go
+++ b/internal/codegen/parser/har_test.go
@@ -1,0 +1,160 @@
+package parser
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestHARParserParseSupportsShortFixture(t *testing.T) {
+	t.Parallel()
+
+	fixture := readTestFixture(t, "har-short.json")
+
+	spec, err := NewHARParser(false).Parse(context.Background(), fixture)
+	if err != nil {
+		t.Fatalf("Parse() returned error: %v", err)
+	}
+
+	if spec.Title != "HAR Recording" {
+		t.Fatalf("expected title %q, got %q", "HAR Recording", spec.Title)
+	}
+	if len(spec.Groups) != 1 {
+		t.Fatalf("expected 1 group, got %d", len(spec.Groups))
+	}
+	group := spec.Groups[0]
+	if group.Name != "httpbinOrg" {
+		t.Fatalf("expected group name %q, got %q", "httpbinOrg", group.Name)
+	}
+	if len(group.Requests) != 1 {
+		t.Fatalf("expected 1 request, got %d", len(group.Requests))
+	}
+	request := findRequest(t, group, "getGet")
+	if request.Path != "/get" {
+		t.Fatalf("expected path %q, got %q", "/get", request.Path)
+	}
+	if len(request.Headers) != 0 || len(request.Params) != 0 || request.Body != nil {
+		t.Fatalf("expected minimal request shape, got %#v", request)
+	}
+}
+
+func TestHARParserParseSupportsHeadersFixture(t *testing.T) {
+	t.Parallel()
+
+	fixture := readTestFixture(t, "har-headers.json")
+
+	spec, err := NewHARParser(false).Parse(context.Background(), fixture)
+	if err != nil {
+		t.Fatalf("Parse() returned error: %v", err)
+	}
+
+	request := findRequest(t, spec.Groups[0], "getGet")
+	if len(request.Headers) != 2 {
+		t.Fatalf("expected 2 request headers, got %#v", request.Headers)
+	}
+	if request.Headers[0].Name != "accept" || request.Headers[1].Name != "x-foo" {
+		t.Fatalf("unexpected headers: %#v", request.Headers)
+	}
+}
+
+func TestHARParserParseSupportsCookiesFixture(t *testing.T) {
+	t.Parallel()
+
+	fixture := readTestFixture(t, "har-cookies.json")
+
+	spec, err := NewHARParser(false).Parse(context.Background(), fixture)
+	if err != nil {
+		t.Fatalf("Parse() returned error: %v", err)
+	}
+
+	request := findRequest(t, spec.Groups[0], "getCookies")
+	if len(request.Headers) != 1 {
+		t.Fatalf("expected cookie header only, got %#v", request.Headers)
+	}
+	if request.Headers[0].Name != "Cookie" || request.Headers[0].Value != "foo=bar; bar=baz" {
+		t.Fatalf("unexpected cookie header: %#v", request.Headers[0])
+	}
+}
+
+func TestHARParserParseSupportsEncodedQueryFixture(t *testing.T) {
+	t.Parallel()
+
+	fixture := readTestFixture(t, "har-query-encoded.json")
+
+	spec, err := NewHARParser(false).Parse(context.Background(), fixture)
+	if err != nil {
+		t.Fatalf("Parse() returned error: %v", err)
+	}
+
+	request := findRequest(t, spec.Groups[0], "getAnything")
+	if len(request.Params) != 5 {
+		t.Fatalf("expected 5 query params, got %#v", request.Params)
+	}
+	if request.Params[0].Name != "stringPound" || request.Params[4].Name != "array" {
+		t.Fatalf("unexpected query params: %#v", request.Params)
+	}
+}
+
+func TestHARParserParseSupportsApplicationJSONFixture(t *testing.T) {
+	t.Parallel()
+
+	fixture := readTestFixture(t, "har-application-json.json")
+
+	spec, err := NewHARParser(false).Parse(context.Background(), fixture)
+	if err != nil {
+		t.Fatalf("Parse() returned error: %v", err)
+	}
+
+	request := findRequest(t, spec.Groups[0], "postPost")
+	if request.Body == nil {
+		t.Fatal("expected raw request body")
+	}
+	if !strings.Contains(request.Body.Raw, `"number":1`) {
+		t.Fatalf("expected recorded JSON body, got %q", request.Body.Raw)
+	}
+	if len(request.Headers) != 1 || request.Headers[0].Name != "content-type" {
+		t.Fatalf("unexpected request headers: %#v", request.Headers)
+	}
+}
+
+func TestHARParserParseFiltersStaticResourcesByDefault(t *testing.T) {
+	t.Parallel()
+
+	fixture := readTestFixture(t, "har-static-asset.json")
+
+	spec, err := NewHARParser(false).Parse(context.Background(), fixture)
+	if err != nil {
+		t.Fatalf("Parse() returned error: %v", err)
+	}
+
+	if len(spec.Groups) != 0 {
+		t.Fatalf("expected static-only fixture to be filtered, got %#v", spec.Groups)
+	}
+}
+
+func TestHARParserParseIncludesStaticWhenRequested(t *testing.T) {
+	t.Parallel()
+
+	fixture := readTestFixture(t, "har-static-asset.json")
+
+	spec, err := NewHARParser(true).Parse(context.Background(), fixture)
+	if err != nil {
+		t.Fatalf("Parse() returned error: %v", err)
+	}
+
+	if len(spec.Groups) != 1 || len(spec.Groups[0].Requests) != 1 {
+		t.Fatalf("expected static entry to be preserved, got %#v", spec.Groups)
+	}
+	if spec.Groups[0].Requests[0].Path != "/assets/app.js" {
+		t.Fatalf("expected static asset path, got %#v", spec.Groups[0].Requests[0])
+	}
+}
+
+func TestHARParserRejectsInvalidDocument(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewHARParser(false).Parse(context.Background(), []byte(`{"log":{}}`))
+	if err == nil {
+		t.Fatal("expected invalid HAR document to return an error")
+	}
+}

--- a/internal/codegen/parser/postman.go
+++ b/internal/codegen/parser/postman.go
@@ -180,7 +180,7 @@ func walkPostmanItem(item postmanItem, ctx postmanWalkContext) error {
 	currentScope := ctx.authScopeName
 	if item.Auth != nil {
 		currentAuth = item.Auth
-		currentScope = lowerCamel(item.Name)
+		currentScope = codegen.LowerCamel(item.Name)
 		if currentScope == "" {
 			currentScope = "item"
 		}
@@ -191,7 +191,7 @@ func walkPostmanItem(item postmanItem, ctx postmanWalkContext) error {
 	currentEvents = append(currentEvents, extractPreRequestScripts(item.Events)...)
 
 	if len(item.Items) > 0 {
-		groupName := lowerCamel(item.Name)
+		groupName := codegen.LowerCamel(item.Name)
 		if groupName == "" {
 			groupName = ctx.groupName
 		}
@@ -223,7 +223,7 @@ func walkPostmanItem(item postmanItem, ctx postmanWalkContext) error {
 	}
 	ctx.ensureGroup(ctx.groupName).Requests = append(ctx.ensureGroup(ctx.groupName).Requests, request)
 	if item.Request.Auth != nil {
-		scope := lowerCamel(item.Name)
+		scope := codegen.LowerCamel(item.Name)
 		if scope == "" {
 			scope = "request"
 		}
@@ -233,7 +233,7 @@ func walkPostmanItem(item postmanItem, ctx postmanWalkContext) error {
 }
 
 func buildPostmanRequest(item postmanItem, inheritedAuth *postmanAuth, inheritedEvents []string, variables map[string]string, nameCounts map[string]int) (codegen.Request, error) {
-	requestName := lowerCamel(item.Name)
+	requestName := codegen.LowerCamel(item.Name)
 	if requestName == "" {
 		requestName = "request"
 	}
@@ -481,7 +481,7 @@ func mapPostmanVariables(value string) string {
 		end += start + 2
 		builder.WriteString(value[:start])
 		name := strings.TrimSpace(value[start+2 : end])
-		builder.WriteString("${" + lowerCamel(name) + "}")
+		builder.WriteString("${" + codegen.LowerCamel(name) + "}")
 		value = value[end+2:]
 	}
 	return builder.String()

--- a/internal/codegen/parser/postman.go
+++ b/internal/codegen/parser/postman.go
@@ -1,0 +1,488 @@
+package parser
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/galax-io/galaxio-cli/internal/codegen"
+)
+
+type PostmanParser struct{}
+
+var _ Parser = (*PostmanParser)(nil)
+
+func NewPostmanParser() *PostmanParser {
+	return &PostmanParser{}
+}
+
+func (p *PostmanParser) Parse(_ context.Context, data []byte) (*codegen.Spec, error) {
+	var collection postmanCollection
+	if err := json.Unmarshal(data, &collection); err != nil {
+		return nil, fmt.Errorf("decode postman collection: %w", err)
+	}
+	if strings.TrimSpace(collection.Info.Name) == "" || !strings.Contains(collection.Info.Schema, "v2.1.0") {
+		return nil, fmt.Errorf("decode postman collection: expected collection v2.1")
+	}
+	if len(collection.Items) == 0 {
+		return nil, fmt.Errorf("decode postman collection: missing items")
+	}
+
+	vars := make(map[string]string, len(collection.Variables))
+	for _, variable := range collection.Variables {
+		key := strings.TrimSpace(variable.Key)
+		if key != "" {
+			vars[key] = variable.Value
+		}
+	}
+
+	spec := &codegen.Spec{
+		Title:   collection.Info.Name,
+		Version: "2.1.0",
+	}
+	authSchemes := make([]codegen.AuthScheme, 0)
+	authSeen := make(map[string]struct{})
+	collectPostmanAuth(authSeen, &authSchemes, "collectionAuth", collection.Auth)
+
+	groupOrder := make([]string, 0)
+	groups := make(map[string]*codegen.Group)
+	ensureGroup := func(name string) *codegen.Group {
+		if group, ok := groups[name]; ok {
+			return group
+		}
+		group := &codegen.Group{Name: name}
+		groups[name] = group
+		groupOrder = append(groupOrder, name)
+		return group
+	}
+
+	defaultScripts := extractPreRequestScripts(collection.Events)
+	nameCounts := make(map[string]int)
+	for _, item := range collection.Items {
+		if err := walkPostmanItem(item, postmanWalkContext{
+			groupName:       "default",
+			authScopeName:   "collection",
+			inheritedAuth:   collection.Auth,
+			inheritedEvents: defaultScripts,
+			variables:       vars,
+			nameCounts:      nameCounts,
+			ensureGroup:     ensureGroup,
+			authSeen:        authSeen,
+			authSchemes:     &authSchemes,
+		}); err != nil {
+			return nil, err
+		}
+	}
+
+	spec.AuthSchemes = authSchemes
+	spec.Groups = make([]codegen.Group, 0, len(groupOrder))
+	for _, name := range groupOrder {
+		spec.Groups = append(spec.Groups, *groups[name])
+	}
+	return spec, nil
+}
+
+type postmanCollection struct {
+	Info      postmanInfo       `json:"info"`
+	Items     []postmanItem     `json:"item"`
+	Variables []postmanVariable `json:"variable"`
+	Auth      *postmanAuth      `json:"auth"`
+	Events    []postmanEvent    `json:"event"`
+}
+
+type postmanInfo struct {
+	Name   string `json:"name"`
+	Schema string `json:"schema"`
+}
+
+type postmanVariable struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+type postmanItem struct {
+	Name    string          `json:"name"`
+	Items   []postmanItem   `json:"item"`
+	Request *postmanRequest `json:"request"`
+	Auth    *postmanAuth    `json:"auth"`
+	Events  []postmanEvent  `json:"event"`
+}
+
+type postmanRequest struct {
+	Method string          `json:"method"`
+	Header []postmanHeader `json:"header"`
+	Body   *postmanBody    `json:"body"`
+	URL    postmanURL      `json:"url"`
+	Auth   *postmanAuth    `json:"auth"`
+}
+
+type postmanHeader struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+type postmanBody struct {
+	Mode string `json:"mode"`
+	Raw  string `json:"raw"`
+}
+
+type postmanURL struct {
+	Raw      string         `json:"raw"`
+	Host     []string       `json:"host"`
+	Path     []string       `json:"path"`
+	Query    []postmanQuery `json:"query"`
+	Protocol string         `json:"protocol"`
+	Port     string         `json:"port"`
+}
+
+type postmanQuery struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+type postmanEvent struct {
+	Listen string        `json:"listen"`
+	Script postmanScript `json:"script"`
+}
+
+type postmanScript struct {
+	Exec []string `json:"exec"`
+}
+
+type postmanAuth struct {
+	Type   string            `json:"type"`
+	Bearer []postmanAuthAttr `json:"bearer"`
+	APIKey []postmanAuthAttr `json:"apikey"`
+	OAuth2 []postmanAuthAttr `json:"oauth2"`
+	Basic  []postmanAuthAttr `json:"basic"`
+}
+
+type postmanAuthAttr struct {
+	Key   string          `json:"key"`
+	Value json.RawMessage `json:"value"`
+}
+
+type postmanWalkContext struct {
+	groupName       string
+	authScopeName   string
+	inheritedAuth   *postmanAuth
+	inheritedEvents []string
+	variables       map[string]string
+	nameCounts      map[string]int
+	ensureGroup     func(string) *codegen.Group
+	authSeen        map[string]struct{}
+	authSchemes     *[]codegen.AuthScheme
+}
+
+func walkPostmanItem(item postmanItem, ctx postmanWalkContext) error {
+	currentAuth := ctx.inheritedAuth
+	currentScope := ctx.authScopeName
+	if item.Auth != nil {
+		currentAuth = item.Auth
+		currentScope = lowerCamel(item.Name)
+		if currentScope == "" {
+			currentScope = "item"
+		}
+		collectPostmanAuth(ctx.authSeen, ctx.authSchemes, currentScope+"Auth", item.Auth)
+	}
+
+	currentEvents := append([]string{}, ctx.inheritedEvents...)
+	currentEvents = append(currentEvents, extractPreRequestScripts(item.Events)...)
+
+	if len(item.Items) > 0 {
+		groupName := lowerCamel(item.Name)
+		if groupName == "" {
+			groupName = ctx.groupName
+		}
+		for _, child := range item.Items {
+			if err := walkPostmanItem(child, postmanWalkContext{
+				groupName:       groupName,
+				authScopeName:   currentScope,
+				inheritedAuth:   currentAuth,
+				inheritedEvents: currentEvents,
+				variables:       ctx.variables,
+				nameCounts:      ctx.nameCounts,
+				ensureGroup:     ctx.ensureGroup,
+				authSeen:        ctx.authSeen,
+				authSchemes:     ctx.authSchemes,
+			}); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	if item.Request == nil {
+		return nil
+	}
+
+	request, err := buildPostmanRequest(item, currentAuth, currentEvents, ctx.variables, ctx.nameCounts)
+	if err != nil {
+		return err
+	}
+	ctx.ensureGroup(ctx.groupName).Requests = append(ctx.ensureGroup(ctx.groupName).Requests, request)
+	if item.Request.Auth != nil {
+		scope := lowerCamel(item.Name)
+		if scope == "" {
+			scope = "request"
+		}
+		collectPostmanAuth(ctx.authSeen, ctx.authSchemes, scope+"Auth", item.Request.Auth)
+	}
+	return nil
+}
+
+func buildPostmanRequest(item postmanItem, inheritedAuth *postmanAuth, inheritedEvents []string, variables map[string]string, nameCounts map[string]int) (codegen.Request, error) {
+	requestName := lowerCamel(item.Name)
+	if requestName == "" {
+		requestName = "request"
+	}
+	nameCounts[requestName]++
+	if nameCounts[requestName] > 1 {
+		requestName = fmt.Sprintf("%s%d", requestName, nameCounts[requestName])
+	}
+
+	requestPath := buildPostmanPath(item.Request.URL, variables)
+	req := codegen.Request{
+		Method:  strings.ToUpper(strings.TrimSpace(item.Request.Method)),
+		Path:    requestPath,
+		Name:    requestName,
+		Summary: item.Name,
+	}
+	if req.Method == "" {
+		req.Method = "GET"
+	}
+	if req.Path == "" {
+		req.Path = "/"
+	}
+
+	for _, script := range inheritedEvents {
+		req.Comments = append(req.Comments, "TODO prerequest script: "+script)
+	}
+
+	for _, header := range item.Request.Header {
+		key := strings.TrimSpace(header.Key)
+		if key == "" {
+			continue
+		}
+		req.Headers = append(req.Headers, codegen.Header{
+			Name:  key,
+			Value: mapPostmanVariables(header.Value),
+		})
+	}
+
+	for _, query := range item.Request.URL.Query {
+		key := strings.TrimSpace(query.Key)
+		if key == "" {
+			continue
+		}
+		req.Params = append(req.Params, codegen.Param{
+			Name:     key,
+			In:       "query",
+			Type:     "string",
+			Required: true,
+		})
+	}
+
+	if body := buildPostmanBody(item.Request.Body); body != nil {
+		req.Body = body
+	}
+
+	if item.Request.Auth != nil {
+		req.Headers = append(req.Headers, postmanAuthHeaders(item.Request.Auth)...)
+	} else if inheritedAuth != nil {
+		req.Headers = append(req.Headers, postmanAuthHeaders(inheritedAuth)...)
+	}
+
+	return req, nil
+}
+
+func buildPostmanBody(body *postmanBody) *codegen.BodySchema {
+	if body == nil || strings.TrimSpace(body.Raw) == "" {
+		return nil
+	}
+	trimmed := mapPostmanVariables(body.Raw)
+	bodyType := "string"
+	if strings.HasPrefix(strings.TrimSpace(trimmed), "{") {
+		bodyType = "object"
+	} else if strings.HasPrefix(strings.TrimSpace(trimmed), "[") {
+		bodyType = "array"
+	}
+	return &codegen.BodySchema{
+		Type:     bodyType,
+		Required: true,
+		Raw:      trimmed,
+	}
+}
+
+func buildPostmanPath(u postmanURL, variables map[string]string) string {
+	pathOnly := "/" + strings.Join(transformPostmanPathSegments(u.Path), "/")
+	pathOnly = strings.ReplaceAll(pathOnly, "//", "/")
+	pathOnly = mapPostmanVariables(pathOnly)
+	if pathOnly == "/" && strings.TrimSpace(u.Raw) == "" {
+		return "/"
+	}
+
+	if shouldUsePostmanRawURL(u, variables) {
+		return mapPostmanVariables(u.Raw)
+	}
+	return pathOnly
+}
+
+func shouldUsePostmanRawURL(u postmanURL, variables map[string]string) bool {
+	raw := strings.TrimSpace(u.Raw)
+	if raw == "" {
+		return false
+	}
+	if strings.HasPrefix(raw, "http://") || strings.HasPrefix(raw, "https://") {
+		return true
+	}
+	if len(u.Host) == 1 {
+		host := strings.TrimSpace(u.Host[0])
+		if strings.HasPrefix(host, "{{") && strings.HasSuffix(host, "}}") {
+			key := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(host, "{{"), "}}"))
+			_, known := variables[key]
+			return !known
+		}
+	}
+	return false
+}
+
+func transformPostmanPathSegments(segments []string) []string {
+	out := make([]string, 0, len(segments))
+	for _, segment := range segments {
+		segment = strings.TrimSpace(segment)
+		if segment == "" {
+			continue
+		}
+		out = append(out, segment)
+	}
+	return out
+}
+
+func extractPreRequestScripts(events []postmanEvent) []string {
+	var scripts []string
+	for _, event := range events {
+		if !strings.EqualFold(event.Listen, "prerequest") {
+			continue
+		}
+		for _, line := range event.Script.Exec {
+			line = strings.TrimSpace(line)
+			if line != "" {
+				scripts = append(scripts, line)
+			}
+		}
+	}
+	return scripts
+}
+
+func collectPostmanAuth(seen map[string]struct{}, schemes *[]codegen.AuthScheme, key string, auth *postmanAuth) {
+	if auth == nil {
+		return
+	}
+	scheme := normalizePostmanAuth(key, auth)
+	if scheme.Key == "" {
+		return
+	}
+	dedupe := scheme.Key + "|" + scheme.Type + "|" + scheme.Name + "|" + scheme.Location
+	if _, ok := seen[dedupe]; ok {
+		return
+	}
+	seen[dedupe] = struct{}{}
+	*schemes = append(*schemes, scheme)
+}
+
+func normalizePostmanAuth(key string, auth *postmanAuth) codegen.AuthScheme {
+	if auth == nil {
+		return codegen.AuthScheme{}
+	}
+	switch strings.ToLower(strings.TrimSpace(auth.Type)) {
+	case "bearer":
+		return codegen.AuthScheme{Key: key, Type: "bearer", Name: "Authorization", Location: "header"}
+	case "apikey":
+		name := findPostmanAuthValue(auth.APIKey, "key")
+		location := findPostmanAuthValue(auth.APIKey, "in")
+		if location == "" {
+			location = "header"
+		}
+		return codegen.AuthScheme{Key: key, Type: "apikey", Name: name, Location: location}
+	case "oauth2":
+		return codegen.AuthScheme{Key: key, Type: "oauth2", Name: "Authorization", Location: "header"}
+	case "basic":
+		return codegen.AuthScheme{Key: key, Type: "basic", Name: "Authorization", Location: "header"}
+	default:
+		return codegen.AuthScheme{Key: key, Type: strings.ToLower(strings.TrimSpace(auth.Type))}
+	}
+}
+
+func postmanAuthHeaders(auth *postmanAuth) []codegen.Header {
+	if auth == nil {
+		return nil
+	}
+	switch strings.ToLower(strings.TrimSpace(auth.Type)) {
+	case "bearer":
+		token := findPostmanAuthValue(auth.Bearer, "token")
+		if token == "" {
+			return nil
+		}
+		return []codegen.Header{{Name: "Authorization", Value: "Bearer " + mapPostmanVariables(token)}}
+	case "apikey":
+		name := findPostmanAuthValue(auth.APIKey, "key")
+		value := findPostmanAuthValue(auth.APIKey, "value")
+		if name == "" || value == "" {
+			return nil
+		}
+		return []codegen.Header{{Name: name, Value: mapPostmanVariables(value)}}
+	default:
+		return nil
+	}
+}
+
+func findPostmanAuthValue(attrs []postmanAuthAttr, key string) string {
+	for _, attr := range attrs {
+		if strings.EqualFold(strings.TrimSpace(attr.Key), key) {
+			return strings.TrimSpace(postmanAuthRawValue(attr.Value))
+		}
+	}
+	return ""
+}
+
+func postmanAuthRawValue(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+
+	var asString string
+	if err := json.Unmarshal(raw, &asString); err == nil {
+		return asString
+	}
+
+	var asArray []string
+	if err := json.Unmarshal(raw, &asArray); err == nil {
+		return strings.Join(asArray, ",")
+	}
+
+	return string(raw)
+}
+
+func mapPostmanVariables(value string) string {
+	var builder strings.Builder
+	for {
+		start := strings.Index(value, "{{")
+		if start < 0 {
+			builder.WriteString(value)
+			break
+		}
+		end := strings.Index(value[start+2:], "}}")
+		if end < 0 {
+			builder.WriteString(value)
+			break
+		}
+		end += start + 2
+		builder.WriteString(value[:start])
+		name := strings.TrimSpace(value[start+2 : end])
+		builder.WriteString("${" + lowerCamel(name) + "}")
+		value = value[end+2:]
+	}
+	return builder.String()
+}

--- a/internal/codegen/parser/postman_test.go
+++ b/internal/codegen/parser/postman_test.go
@@ -1,0 +1,127 @@
+package parser
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestPostmanParserParseBuildsSpecFromCollection(t *testing.T) {
+	t.Parallel()
+
+	fixture := readTestFixture(t, "sample-collection.json")
+
+	spec, err := NewPostmanParser().Parse(context.Background(), fixture)
+	if err != nil {
+		t.Fatalf("Parse() returned error: %v", err)
+	}
+
+	if spec.Title != "Orders API Collection" {
+		t.Fatalf("expected title %q, got %q", "Orders API Collection", spec.Title)
+	}
+	if spec.Version != "2.1.0" {
+		t.Fatalf("expected version %q, got %q", "2.1.0", spec.Version)
+	}
+	if len(spec.Groups) != 2 {
+		t.Fatalf("expected 2 groups, got %d", len(spec.Groups))
+	}
+
+	orders := findGroup(t, spec, "orders")
+	if len(orders.Requests) != 2 {
+		t.Fatalf("expected 2 requests in orders group, got %d", len(orders.Requests))
+	}
+
+	createOrder := findRequest(t, orders, "createOrder")
+	if createOrder.Method != "POST" {
+		t.Fatalf("expected method %q, got %q", "POST", createOrder.Method)
+	}
+	if createOrder.Path != "/api/v1/orders" {
+		t.Fatalf("expected path %q, got %q", "/api/v1/orders", createOrder.Path)
+	}
+	if createOrder.Body == nil {
+		t.Fatal("expected createOrder body")
+	}
+	if !strings.Contains(createOrder.Body.Raw, `"sku": "${sku}"`) {
+		t.Fatalf("expected variable mapping in raw body, got %q", createOrder.Body.Raw)
+	}
+	if len(createOrder.Comments) == 0 || !strings.Contains(createOrder.Comments[0], "TODO prerequest script:") {
+		t.Fatalf("expected pre-request TODO comments, got %#v", createOrder.Comments)
+	}
+
+	getOrder := findRequest(t, orders, "getOrder")
+	if getOrder.Path != "/api/v1/orders/${orderId}" {
+		t.Fatalf("expected path placeholder mapping, got %q", getOrder.Path)
+	}
+	if len(getOrder.Params) != 1 || getOrder.Params[0].Name != "expand" {
+		t.Fatalf("expected query param mapping, got %#v", getOrder.Params)
+	}
+
+	health := findGroup(t, spec, "default")
+	if len(health.Requests) != 1 {
+		t.Fatalf("expected 1 request in default group, got %d", len(health.Requests))
+	}
+	if health.Requests[0].Name != "healthCheck" {
+		t.Fatalf("expected top-level request name %q, got %q", "healthCheck", health.Requests[0].Name)
+	}
+
+	if len(spec.AuthSchemes) != 2 {
+		t.Fatalf("expected 2 auth scheme hints, got %d", len(spec.AuthSchemes))
+	}
+	bearer := findAuthScheme(t, spec, "collectionAuth")
+	if bearer.Type != "bearer" {
+		t.Fatalf("expected collection bearer auth, got %#v", bearer)
+	}
+	apiKey := findAuthScheme(t, spec, "ordersAuth")
+	if apiKey.Type != "apikey" || apiKey.Name != "X-API-Key" || apiKey.Location != "header" {
+		t.Fatalf("expected folder api key auth, got %#v", apiKey)
+	}
+}
+
+func TestPostmanParserRejectsInvalidDocument(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewPostmanParser().Parse(context.Background(), []byte(`{"info":{}}`))
+	if err == nil {
+		t.Fatal("expected invalid Postman document to return an error")
+	}
+}
+
+func TestPostmanParserParseSupportsZitadelCollectionFixture(t *testing.T) {
+	t.Parallel()
+
+	fixture := readTestFixture(t, "zitadel.postman_collection.json")
+
+	spec, err := NewPostmanParser().Parse(context.Background(), fixture)
+	if err != nil {
+		t.Fatalf("Parse() returned error: %v", err)
+	}
+
+	if spec.Title != "ZITADEL with Postman" {
+		t.Fatalf("expected title %q, got %q", "ZITADEL with Postman", spec.Title)
+	}
+	if spec.Version != "2.1.0" {
+		t.Fatalf("expected version %q, got %q", "2.1.0", spec.Version)
+	}
+
+	defaultGroup := findGroup(t, spec, "default")
+	if len(defaultGroup.Requests) != 7 {
+		t.Fatalf("expected 7 top-level requests, got %d", len(defaultGroup.Requests))
+	}
+
+	addProject := findRequest(t, defaultGroup, "addZitadelProject")
+	if addProject.Path != "${yourZitadelDomain}/management/v1/projects" {
+		t.Fatalf("expected add project path, got %q", addProject.Path)
+	}
+	if addProject.Body == nil || !strings.Contains(addProject.Body.Raw, `"name": "MyPostmanProject"`) {
+		t.Fatalf("expected raw body for add project, got %#v", addProject.Body)
+	}
+
+	loginUserinfo := findRequest(t, defaultGroup, "loginUserAndCallUserinfoEndpoint")
+	if loginUserinfo.Path != "${yourZitadelDomain}/oidc/v1/userinfo" && loginUserinfo.Path != "/oidc/v1/userinfo" {
+		t.Fatalf("unexpected userinfo path %q", loginUserinfo.Path)
+	}
+
+	if len(spec.AuthSchemes) == 0 {
+		t.Fatal("expected auth schemes from per-request auth blocks")
+	}
+}

--- a/internal/codegen/parser/swagger.go
+++ b/internal/codegen/parser/swagger.go
@@ -6,7 +6,6 @@ import (
 	"net/url"
 	"regexp"
 	"strings"
-	"unicode"
 
 	"github.com/galax-io/galaxio-cli/internal/codegen"
 	"github.com/pb33f/libopenapi"
@@ -512,7 +511,7 @@ func groupNameFor(path string, operation *v2.Operation) string {
 	if operation != nil {
 		for _, tag := range operation.Tags {
 			if strings.TrimSpace(tag) != "" {
-				return lowerCamel(tag)
+				return codegen.LowerCamel(tag)
 			}
 		}
 	}
@@ -522,14 +521,14 @@ func groupNameFor(path string, operation *v2.Operation) string {
 		return "default"
 	}
 
-	return lowerCamel(segments[0])
+	return codegen.LowerCamel(segments[0])
 }
 
 func groupNameForV3(path string, operation *v3.Operation) string {
 	if operation != nil {
 		for _, tag := range operation.Tags {
 			if strings.TrimSpace(tag) != "" {
-				return lowerCamel(tag)
+				return codegen.LowerCamel(tag)
 			}
 		}
 	}
@@ -539,17 +538,17 @@ func groupNameForV3(path string, operation *v3.Operation) string {
 		return "default"
 	}
 
-	return lowerCamel(segments[0])
+	return codegen.LowerCamel(segments[0])
 }
 
 func requestNameFor(method string, path string, operation *v2.Operation) string {
 	if operation != nil && strings.TrimSpace(operation.OperationId) != "" {
-		return lowerCamel(operation.OperationId)
+		return codegen.LowerCamel(operation.OperationId)
 	}
 
 	segments := meaningfulSegments(path)
 	if len(segments) == 0 {
-		return lowerCamel(method + " request")
+		return codegen.LowerCamel(method + " request")
 	}
 
 	words := make([]string, 0, len(segments)+1)
@@ -558,17 +557,17 @@ func requestNameFor(method string, path string, operation *v2.Operation) string 
 		words = append(words, segment)
 	}
 
-	return lowerCamel(strings.Join(words, " "))
+	return codegen.LowerCamel(strings.Join(words, " "))
 }
 
 func requestNameForV3(method string, path string, operation *v3.Operation) string {
 	if operation != nil && strings.TrimSpace(operation.OperationId) != "" {
-		return lowerCamel(operation.OperationId)
+		return codegen.LowerCamel(operation.OperationId)
 	}
 
 	segments := meaningfulSegments(path)
 	if len(segments) == 0 {
-		return lowerCamel(method + " request")
+		return codegen.LowerCamel(method + " request")
 	}
 
 	words := make([]string, 0, len(segments)+1)
@@ -577,7 +576,7 @@ func requestNameForV3(method string, path string, operation *v3.Operation) strin
 		words = append(words, segment)
 	}
 
-	return lowerCamel(strings.Join(words, " "))
+	return codegen.LowerCamel(strings.Join(words, " "))
 }
 
 func basePathFromServers(servers []*v3.Server) string {
@@ -628,62 +627,4 @@ func meaningfulSegments(path string) []string {
 	}
 
 	return segments
-}
-
-func lowerCamel(value string) string {
-	words := splitWords(value)
-	if len(words) == 0 {
-		return ""
-	}
-
-	for i := range words {
-		words[i] = strings.ToLower(words[i])
-	}
-
-	result := words[0]
-	for _, word := range words[1:] {
-		result += strings.ToUpper(word[:1]) + word[1:]
-	}
-
-	return result
-}
-
-func splitWords(value string) []string {
-	replacer := strings.NewReplacer("/", " ", "-", " ", "_", " ", ".", " ")
-	value = replacer.Replace(value)
-
-	parts := strings.FieldsFunc(value, func(r rune) bool {
-		return unicode.IsSpace(r) || unicode.IsPunct(r)
-	})
-
-	words := make([]string, 0, len(parts))
-	for _, part := range parts {
-		if part == "" {
-			continue
-		}
-
-		var builder strings.Builder
-		runes := []rune(part)
-		for i, r := range runes {
-			if i > 0 && unicode.IsUpper(r) && (unicode.IsLower(runes[i-1]) || i+1 < len(runes) && unicode.IsLower(runes[i+1])) {
-				words = appendWord(words, builder.String())
-				builder.Reset()
-			}
-			builder.WriteRune(r)
-		}
-		words = appendWord(words, builder.String())
-	}
-
-	return words
-}
-
-func appendWord(words []string, word string) []string {
-	word = strings.TrimSpace(word)
-	if word == "" {
-		return words
-	}
-	if strings.HasPrefix(word, "{") && strings.HasSuffix(word, "}") {
-		return words
-	}
-	return append(words, word)
 }

--- a/internal/codegen/parser/swagger.go
+++ b/internal/codegen/parser/swagger.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"regexp"
 	"strings"
 	"unicode"
@@ -11,28 +12,42 @@ import (
 	"github.com/pb33f/libopenapi"
 	highbase "github.com/pb33f/libopenapi/datamodel/high/base"
 	v2 "github.com/pb33f/libopenapi/datamodel/high/v2"
+	v3 "github.com/pb33f/libopenapi/datamodel/high/v3"
+	"github.com/pb33f/libopenapi/orderedmap"
 )
 
 var versionSegmentPattern = regexp.MustCompile(`^v\d+$`)
 
-// SwaggerParser parses Swagger 2.0 documents into the shared codegen IR.
+// SwaggerParser parses Swagger/OpenAPI documents into the shared codegen IR.
 type SwaggerParser struct{}
 
 var _ Parser = (*SwaggerParser)(nil)
 
-// NewSwaggerParser creates a Swagger 2.0 parser instance.
+// NewSwaggerParser creates a Swagger/OpenAPI parser instance.
 func NewSwaggerParser() *SwaggerParser {
 	return &SwaggerParser{}
 }
 
-// Parse converts Swagger 2.0 bytes into the codegen intermediate
-// representation.
+// Parse converts Swagger/OpenAPI bytes into the codegen intermediate representation.
 func (p *SwaggerParser) Parse(_ context.Context, data []byte) (*codegen.Spec, error) {
 	document, err := libopenapi.NewDocument(data)
 	if err != nil {
 		return nil, fmt.Errorf("create swagger document: %w", err)
 	}
 
+	specInfo := document.GetSpecInfo()
+	if specInfo == nil {
+		return nil, fmt.Errorf("inspect swagger document: missing spec info")
+	}
+
+	if specInfo.VersionNumeric >= 3 {
+		return parseV3Document(document)
+	}
+
+	return parseV2Document(document)
+}
+
+func parseV2Document(document libopenapi.Document) (*codegen.Spec, error) {
 	model, err := document.BuildV2Model()
 	if err != nil {
 		return nil, fmt.Errorf("build swagger v2 model: %w", err)
@@ -46,10 +61,36 @@ func (p *SwaggerParser) Parse(_ context.Context, data []byte) (*codegen.Spec, er
 		spec.Version = model.Model.Info.Version
 	}
 
-	authSchemes := extractAuthSchemes(model.Model.SecurityDefinitions)
-	spec.AuthSchemes = authSchemes
+	spec.AuthSchemes = extractAuthSchemes(model.Model.SecurityDefinitions)
 
 	groups, err := extractGroups(model.Model.Paths)
+	if err != nil {
+		return nil, err
+	}
+	spec.Groups = groups
+
+	return spec, nil
+}
+
+func parseV3Document(document libopenapi.Document) (*codegen.Spec, error) {
+	model, err := document.BuildV3Model()
+	if err != nil {
+		return nil, fmt.Errorf("build openapi v3 model: %w", err)
+	}
+
+	spec := &codegen.Spec{
+		BasePath: basePathFromServers(model.Model.Servers),
+	}
+	if model.Model.Info != nil {
+		spec.Title = model.Model.Info.Title
+		spec.Version = model.Model.Info.Version
+	}
+
+	if model.Model.Components != nil {
+		spec.AuthSchemes = extractAuthSchemesV3(model.Model.Components.SecuritySchemes)
+	}
+
+	groups, err := extractGroupsV3(model.Model.Paths)
 	if err != nil {
 		return nil, err
 	}
@@ -68,6 +109,24 @@ func extractAuthSchemes(definitions *v2.SecurityDefinitions) []codegen.AuthSchem
 		authSchemes = append(authSchemes, codegen.AuthScheme{
 			Key:      key,
 			Type:     normalizeAuthType(scheme),
+			Name:     scheme.Name,
+			Location: scheme.In,
+		})
+	}
+
+	return authSchemes
+}
+
+func extractAuthSchemesV3(definitions *orderedmap.Map[string, *v3.SecurityScheme]) []codegen.AuthScheme {
+	if definitions == nil {
+		return nil
+	}
+
+	authSchemes := make([]codegen.AuthScheme, 0)
+	for key, scheme := range definitions.FromOldest() {
+		authSchemes = append(authSchemes, codegen.AuthScheme{
+			Key:      key,
+			Type:     normalizeAuthTypeV3(scheme),
 			Name:     scheme.Name,
 			Location: scheme.In,
 		})
@@ -103,6 +162,47 @@ func extractGroups(paths *v2.Paths) ([]codegen.Group, error) {
 			}
 
 			request, err := buildRequest(method, path, pathItem, operation)
+			if err != nil {
+				return nil, fmt.Errorf("build request for %s %s: %w", strings.ToUpper(method), path, err)
+			}
+			groups[idx].Requests = append(groups[idx].Requests, request)
+		}
+	}
+
+	if len(groups) == 0 {
+		return nil, nil
+	}
+
+	return groups, nil
+}
+
+func extractGroupsV3(paths *v3.Paths) ([]codegen.Group, error) {
+	if paths == nil || paths.PathItems == nil {
+		return nil, nil
+	}
+
+	groupIndex := make(map[string]int)
+	groups := make([]codegen.Group, 0)
+
+	for path, pathItem := range paths.PathItems.FromOldest() {
+		if pathItem == nil {
+			continue
+		}
+
+		for method, operation := range pathItem.GetOperations().FromOldest() {
+			if operation == nil {
+				continue
+			}
+
+			groupName := groupNameForV3(path, operation)
+			idx, ok := groupIndex[groupName]
+			if !ok {
+				groupIndex[groupName] = len(groups)
+				groups = append(groups, codegen.Group{Name: groupName})
+				idx = len(groups) - 1
+			}
+
+			request, err := buildRequestV3(method, path, pathItem, operation)
 			if err != nil {
 				return nil, fmt.Errorf("build request for %s %s: %w", strings.ToUpper(method), path, err)
 			}
@@ -181,6 +281,83 @@ func buildRequest(method string, path string, pathItem *v2.PathItem, operation *
 	return request, nil
 }
 
+func buildRequestV3(method string, path string, pathItem *v3.PathItem, operation *v3.Operation) (codegen.Request, error) {
+	request := codegen.Request{
+		Method:  strings.ToUpper(method),
+		Path:    path,
+		Name:    requestNameForV3(method, path, operation),
+		Summary: operation.Summary,
+	}
+
+	parameters := append([]*v3.Parameter{}, pathItem.Parameters...)
+	parameters = append(parameters, operation.Parameters...)
+
+	for _, parameter := range parameters {
+		if parameter == nil {
+			continue
+		}
+
+		required := parameter.Required != nil && *parameter.Required
+		switch parameter.In {
+		case "header":
+			request.Headers = append(request.Headers, codegen.Header{
+				Name:     parameter.Name,
+				Required: required,
+			})
+		default:
+			paramType, paramFormat := extractV3ParameterSchema(parameter)
+			request.Params = append(request.Params, codegen.Param{
+				Name:     parameter.Name,
+				In:       parameter.In,
+				Type:     paramType,
+				Format:   paramFormat,
+				Required: required,
+			})
+		}
+	}
+
+	if operation.RequestBody != nil {
+		body, err := buildRequestBodyV3(operation.RequestBody)
+		if err != nil {
+			return codegen.Request{}, fmt.Errorf("build request body: %w", err)
+		}
+		request.Body = body
+	}
+
+	if operation.Responses != nil {
+		if operation.Responses.Codes != nil {
+			for code, response := range operation.Responses.Codes.FromOldest() {
+				request.Responses = append(request.Responses, codegen.Response{
+					StatusCode:  code,
+					Description: response.Description,
+				})
+			}
+		}
+		if operation.Responses.Default != nil {
+			request.Responses = append(request.Responses, codegen.Response{
+				StatusCode:  "default",
+				Description: operation.Responses.Default.Description,
+			})
+		}
+	}
+
+	return request, nil
+}
+
+func buildRequestBodyV3(requestBody *v3.RequestBody) (*codegen.BodySchema, error) {
+	if requestBody == nil {
+		return nil, nil
+	}
+
+	mediaType := selectRequestBodyMediaType(requestBody.Content)
+	if mediaType == nil || mediaType.Schema == nil {
+		return nil, nil
+	}
+
+	required := requestBody.Required != nil && *requestBody.Required
+	return buildBodySchema(mediaType.Schema, "", required)
+}
+
 func buildBodySchema(proxy *highbase.SchemaProxy, name string, required bool) (*codegen.BodySchema, error) {
 	if proxy == nil {
 		return nil, nil
@@ -230,8 +407,53 @@ func buildBodySchema(proxy *highbase.SchemaProxy, name string, required bool) (*
 	return body, nil
 }
 
+func extractV3ParameterSchema(parameter *v3.Parameter) (string, string) {
+	if parameter == nil {
+		return "", ""
+	}
+
+	if parameter.Schema != nil {
+		schema := parameter.Schema.Schema()
+		if schema != nil {
+			return schemaType(schema), schema.Format
+		}
+	}
+
+	if mediaType := selectRequestBodyMediaType(parameter.Content); mediaType != nil && mediaType.Schema != nil {
+		schema := mediaType.Schema.Schema()
+		if schema != nil {
+			return schemaType(schema), schema.Format
+		}
+	}
+
+	return "", ""
+}
+
+func selectRequestBodyMediaType(content *orderedmap.Map[string, *v3.MediaType]) *v3.MediaType {
+	if content == nil {
+		return nil
+	}
+
+	for _, mediaTypeName := range []string{"application/json", "application/*+json"} {
+		if mediaType, ok := content.Get(mediaTypeName); ok {
+			return mediaType
+		}
+	}
+
+	for _, mediaType := range content.FromOldest() {
+		return mediaType
+	}
+
+	return nil
+}
+
 func schemaType(schema *highbase.Schema) string {
 	if len(schema.Type) > 0 {
+		for _, candidate := range schema.Type {
+			if !strings.EqualFold(candidate, "null") {
+				return candidate
+			}
+		}
 		return schema.Type[0]
 	}
 	if schema.Properties != nil {
@@ -263,7 +485,47 @@ func normalizeAuthType(scheme *v2.SecurityScheme) string {
 	}
 }
 
+func normalizeAuthTypeV3(scheme *v3.SecurityScheme) string {
+	if scheme == nil {
+		return ""
+	}
+
+	switch strings.ToLower(scheme.Type) {
+	case "apikey":
+		return "apikey"
+	case "http":
+		switch strings.ToLower(scheme.Scheme) {
+		case "bearer":
+			return "bearer"
+		case "basic":
+			return "basic"
+		}
+		return strings.ToLower(scheme.Scheme)
+	case "oauth2":
+		return "oauth2"
+	default:
+		return strings.ToLower(scheme.Type)
+	}
+}
+
 func groupNameFor(path string, operation *v2.Operation) string {
+	if operation != nil {
+		for _, tag := range operation.Tags {
+			if strings.TrimSpace(tag) != "" {
+				return lowerCamel(tag)
+			}
+		}
+	}
+
+	segments := meaningfulSegments(path)
+	if len(segments) == 0 {
+		return "default"
+	}
+
+	return lowerCamel(segments[0])
+}
+
+func groupNameForV3(path string, operation *v3.Operation) string {
 	if operation != nil {
 		for _, tag := range operation.Tags {
 			if strings.TrimSpace(tag) != "" {
@@ -297,6 +559,54 @@ func requestNameFor(method string, path string, operation *v2.Operation) string 
 	}
 
 	return lowerCamel(strings.Join(words, " "))
+}
+
+func requestNameForV3(method string, path string, operation *v3.Operation) string {
+	if operation != nil && strings.TrimSpace(operation.OperationId) != "" {
+		return lowerCamel(operation.OperationId)
+	}
+
+	segments := meaningfulSegments(path)
+	if len(segments) == 0 {
+		return lowerCamel(method + " request")
+	}
+
+	words := make([]string, 0, len(segments)+1)
+	words = append(words, strings.ToLower(method))
+	for _, segment := range segments {
+		words = append(words, segment)
+	}
+
+	return lowerCamel(strings.Join(words, " "))
+}
+
+func basePathFromServers(servers []*v3.Server) string {
+	for _, server := range servers {
+		if server == nil || strings.TrimSpace(server.URL) == "" {
+			continue
+		}
+
+		serverURL := strings.TrimSpace(server.URL)
+		parsed, err := url.Parse(serverURL)
+		if err != nil {
+			if strings.HasPrefix(serverURL, "/") {
+				return strings.TrimRight(serverURL, "/")
+			}
+			continue
+		}
+
+		if parsed.Path == "" {
+			return ""
+		}
+
+		path := strings.TrimRight(parsed.Path, "/")
+		if path == "" {
+			return "/"
+		}
+		return path
+	}
+
+	return ""
 }
 
 func meaningfulSegments(path string) []string {

--- a/internal/codegen/parser/swagger_helpers_test.go
+++ b/internal/codegen/parser/swagger_helpers_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/galax-io/galaxio-cli/internal/codegen"
 	highbase "github.com/pb33f/libopenapi/datamodel/high/base"
 	v2 "github.com/pb33f/libopenapi/datamodel/high/v2"
 	liborderedmap "github.com/pb33f/libopenapi/orderedmap"
@@ -201,22 +202,12 @@ func TestRequestNameForFallbacks(t *testing.T) {
 	}
 }
 
-func TestAppendWordSkipsEmptyAndPathParams(t *testing.T) {
+func TestSplitWordsSplitsPathLikeTokens(t *testing.T) {
 	t.Parallel()
 
-	words := appendWord(nil, "  ")
-	if len(words) != 0 {
-		t.Fatalf("expected empty result for blank word, got %#v", words)
-	}
-
-	words = appendWord(words, "{id}")
-	if len(words) != 0 {
-		t.Fatalf("expected path param word to be skipped, got %#v", words)
-	}
-
-	words = appendWord(words, "pets")
-	if len(words) != 1 || words[0] != "pets" {
-		t.Fatalf("expected regular word to be appended, got %#v", words)
+	words := codegen.SplitWords("  /{id}/pets")
+	if len(words) != 2 || words[0] != "id" || words[1] != "pets" {
+		t.Fatalf("expected path-like tokens to be split consistently, got %#v", words)
 	}
 }
 

--- a/internal/codegen/parser/swagger_test.go
+++ b/internal/codegen/parser/swagger_test.go
@@ -250,6 +250,140 @@ func TestSwaggerParserParseSupportsExpandedSwagger2Fixture(t *testing.T) {
 	}
 }
 
+func TestSwaggerParserParseBuildsSpecFromOpenAPI3(t *testing.T) {
+	fixture := readTestFixture(t, "petstore-openapi3.yaml")
+
+	spec, err := NewSwaggerParser().Parse(context.Background(), fixture)
+	if err != nil {
+		t.Fatalf("Parse() returned error: %v", err)
+	}
+
+	if spec.Title != "Petstore OpenAPI 3" {
+		t.Fatalf("expected title %q, got %q", "Petstore OpenAPI 3", spec.Title)
+	}
+	if spec.Version != "3.0.0" {
+		t.Fatalf("expected version %q, got %q", "3.0.0", spec.Version)
+	}
+	if spec.BasePath != "/api/v3" {
+		t.Fatalf("expected base path %q, got %q", "/api/v3", spec.BasePath)
+	}
+
+	pets := findGroup(t, spec, "pets")
+	if len(pets.Requests) != 3 {
+		t.Fatalf("expected 3 requests in pets group, got %d", len(pets.Requests))
+	}
+
+	createPet := findRequest(t, pets, "createPet")
+	if createPet.Method != "POST" || createPet.Path != "/pets" {
+		t.Fatalf("unexpected createPet request %#v", createPet)
+	}
+	if createPet.Body == nil || createPet.Body.Type != "object" {
+		t.Fatalf("expected createPet body object, got %#v", createPet.Body)
+	}
+	nameField := findField(t, createPet.Body, "name")
+	if !nameField.Required || nameField.Type != "string" {
+		t.Fatalf("expected required string name field, got %#v", nameField)
+	}
+	metadataField := findField(t, createPet.Body, "metadata")
+	nicknameField := findField(t, metadataField, "nickname")
+	if nicknameField.Type != "string" {
+		t.Fatalf("expected nested nickname field, got %#v", nicknameField)
+	}
+
+	deletePet := findRequest(t, pets, "deletePet")
+	if len(deletePet.Headers) != 1 || deletePet.Headers[0].Name != "X-Trace-Id" {
+		t.Fatalf("expected X-Trace-Id header, got %#v", deletePet.Headers)
+	}
+	if len(deletePet.Params) != 1 || deletePet.Params[0].Name != "petId" || deletePet.Params[0].In != "path" {
+		t.Fatalf("expected petId path param, got %#v", deletePet.Params)
+	}
+
+	if len(spec.AuthSchemes) != 2 {
+		t.Fatalf("expected 2 auth schemes, got %d", len(spec.AuthSchemes))
+	}
+	apiKey := findAuthScheme(t, spec, "ApiKeyAuth")
+	if apiKey.Type != "apikey" || apiKey.Name != "X-API-Key" || apiKey.Location != "header" {
+		t.Fatalf("expected api key auth scheme, got %#v", apiKey)
+	}
+	bearer := findAuthScheme(t, spec, "BearerAuth")
+	if bearer.Type != "bearer" {
+		t.Fatalf("expected bearer auth scheme, got %#v", bearer)
+	}
+}
+
+func TestSwaggerParserParseBuildsSpecFromOpenAPI31(t *testing.T) {
+	fixture := readTestFixture(t, "petstore-openapi31.yaml")
+
+	spec, err := NewSwaggerParser().Parse(context.Background(), fixture)
+	if err != nil {
+		t.Fatalf("Parse() returned error: %v", err)
+	}
+
+	if spec.Title != "Petstore OpenAPI 3.1" {
+		t.Fatalf("expected title %q, got %q", "Petstore OpenAPI 3.1", spec.Title)
+	}
+	if spec.Version != "3.1.0" {
+		t.Fatalf("expected version %q, got %q", "3.1.0", spec.Version)
+	}
+	if spec.BasePath != "/platform/v31" {
+		t.Fatalf("expected base path %q, got %q", "/platform/v31", spec.BasePath)
+	}
+	if len(spec.Groups) != 1 {
+		t.Fatalf("expected only paths to be rendered, got %#v", spec.Groups)
+	}
+
+	pets := findGroup(t, spec, "pets")
+	upsertPet := findRequest(t, pets, "upsertPet")
+	if upsertPet.Body == nil || upsertPet.Body.Type != "object" {
+		t.Fatalf("expected upsertPet body object, got %#v", upsertPet.Body)
+	}
+	nicknameField := findField(t, upsertPet.Body, "nickname")
+	if nicknameField.Type != "string" {
+		t.Fatalf("expected nullable nickname to normalize to string, got %#v", nicknameField)
+	}
+	aliasesField := findField(t, upsertPet.Body, "aliases")
+	if aliasesField.Type != "array" || aliasesField.Items == nil || aliasesField.Items.Type != "string" {
+		t.Fatalf("expected aliases items to normalize to string, got %#v", aliasesField)
+	}
+}
+
+func TestSwaggerParserParseSupportsOpenAPIExamplesAndWebhooksOnly(t *testing.T) {
+	t.Run("official examples document falls back to default group", func(t *testing.T) {
+		spec, err := NewSwaggerParser().Parse(context.Background(), readTestFixture(t, "api-with-examples-openapi3.yaml"))
+		if err != nil {
+			t.Fatalf("Parse() returned error: %v", err)
+		}
+
+		if len(spec.Groups) != 1 {
+			t.Fatalf("expected 1 group, got %d", len(spec.Groups))
+		}
+		group := findGroup(t, spec, "default")
+		if len(group.Requests) != 2 {
+			t.Fatalf("expected 2 requests in default group, got %d", len(group.Requests))
+		}
+		listVersions := findRequest(t, group, "listVersionsv2")
+		if listVersions.Summary != "List API versions" {
+			t.Fatalf("expected summary to be preserved, got %#v", listVersions)
+		}
+		if len(listVersions.Responses) != 2 {
+			t.Fatalf("expected response metadata to be preserved, got %#v", listVersions.Responses)
+		}
+	})
+
+	t.Run("webhooks-only 3.1 document is accepted and ignored for generation", func(t *testing.T) {
+		spec, err := NewSwaggerParser().Parse(context.Background(), readTestFixture(t, "webhook-example-openapi31.yaml"))
+		if err != nil {
+			t.Fatalf("Parse() returned error: %v", err)
+		}
+		if spec.Title != "Webhook Example" {
+			t.Fatalf("expected title %q, got %q", "Webhook Example", spec.Title)
+		}
+		if len(spec.Groups) != 0 {
+			t.Fatalf("expected no groups for webhooks-only document, got %#v", spec.Groups)
+		}
+	})
+}
+
 func readTestFixture(t *testing.T, name string) []byte {
 	t.Helper()
 

--- a/internal/codegen/renderer/renderer.go
+++ b/internal/codegen/renderer/renderer.go
@@ -1,0 +1,174 @@
+package renderer
+
+import (
+	"bytes"
+	"fmt"
+	"io/fs"
+	"path"
+	"sort"
+	"strings"
+	"text/template"
+
+	"github.com/galax-io/galaxio-cli/internal/codegen"
+	cgtemplates "github.com/galax-io/galaxio-cli/internal/codegen/templates"
+)
+
+// OutputFile describes one generated file.
+type OutputFile struct {
+	Path    string
+	Content []byte
+}
+
+// RenderOptions configures the generated source layout.
+type RenderOptions struct {
+	Package string
+}
+
+// Renderer renders codegen IR into language-specific output files.
+type Renderer struct {
+	templates fs.FS
+	funcMap   template.FuncMap
+}
+
+// NewRenderer constructs a renderer backed by the embedded template pack.
+func NewRenderer() *Renderer {
+	return &Renderer{
+		templates: cgtemplates.Files,
+		funcMap: template.FuncMap{
+			"renderBody": renderBodyTemplate,
+		},
+	}
+}
+
+// Render emits Scala/sbt Gatling files for the supplied IR spec.
+func (r *Renderer) Render(spec *codegen.Spec, opts RenderOptions) ([]OutputFile, error) {
+	if spec == nil {
+		return nil, fmt.Errorf("render spec: spec is nil")
+	}
+
+	pkg := strings.TrimSpace(opts.Package)
+	if pkg == "" {
+		return nil, fmt.Errorf("render spec: package is required")
+	}
+
+	capHint := len(spec.Groups) * 2
+	if len(spec.AuthSchemes) > 0 {
+		capHint++
+	}
+	for _, group := range spec.Groups {
+		for _, request := range group.Requests {
+			if request.Body != nil {
+				capHint++
+			}
+		}
+	}
+
+	files := make([]OutputFile, 0, capHint)
+	for _, group := range spec.Groups {
+		groupFiles, err := r.renderGroup(spec, group, pkg)
+		if err != nil {
+			return nil, err
+		}
+		files = append(files, groupFiles...)
+	}
+
+	if len(spec.AuthSchemes) > 0 {
+		content, err := r.renderTemplate("scala-sbt/auth_actions.scala.tmpl", authActionsTemplateData{
+			Package: pkg + ".cases",
+			Schemes: spec.AuthSchemes,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("render auth actions: %w", err)
+		}
+		files = append(files, OutputFile{
+			Path:    path.Join("cases", "AuthActions.scala"),
+			Content: content,
+		})
+	}
+
+	sort.Slice(files, func(i, j int) bool {
+		return files[i].Path < files[j].Path
+	})
+
+	return files, nil
+}
+
+func (r *Renderer) renderGroup(spec *codegen.Spec, group codegen.Group, pkg string) ([]OutputFile, error) {
+	groupName := pascalCase(group.Name)
+	if groupName == "" {
+		groupName = "Default"
+	}
+
+	requests := make([]actionsRequestTemplateData, 0, len(group.Requests))
+	bodyFiles := make([]OutputFile, 0)
+	execCalls := make([]string, 0, len(group.Requests))
+	for _, request := range group.Requests {
+		requestView := buildRequestTemplateData(spec, request)
+		requests = append(requests, requestView)
+		execCalls = append(execCalls, groupName+"Actions."+requestView.Name)
+
+		if request.Body != nil {
+			content, err := r.renderTemplate("scala-sbt/body.json.tmpl", bodyTemplateData{Body: request.Body})
+			if err != nil {
+				return nil, fmt.Errorf("render body %s: %w", request.Name, err)
+			}
+			bodyFiles = append(bodyFiles, OutputFile{
+				Path:    path.Join("resources", "bodies", requestView.BodyFile),
+				Content: content,
+			})
+		}
+	}
+
+	actionsContent, err := r.renderTemplate("scala-sbt/actions.scala.tmpl", actionsTemplateData{
+		Package:    pkg + ".cases",
+		ObjectName: groupName + "Actions",
+		Requests:   requests,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("render actions for group %s: %w", group.Name, err)
+	}
+
+	scenarioContent, err := r.renderTemplate("scala-sbt/scenario.scala.tmpl", scenarioTemplateData{
+		Package:      pkg + ".scenarios",
+		CasesImport:  pkg + ".cases._",
+		ObjectName:   groupName + "Scenario",
+		ScenarioName: groupName + " Scenario",
+		ExecCalls:    execCalls,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("render scenario for group %s: %w", group.Name, err)
+	}
+
+	files := []OutputFile{
+		{
+			Path:    path.Join("cases", groupName+"Actions.scala"),
+			Content: actionsContent,
+		},
+		{
+			Path:    path.Join("scenarios", groupName+"Scenario.scala"),
+			Content: scenarioContent,
+		},
+	}
+	files = append(files, bodyFiles...)
+
+	return files, nil
+}
+
+func (r *Renderer) renderTemplate(name string, data any) ([]byte, error) {
+	tmpl, err := template.New(path.Base(name)).Funcs(r.funcMap).ParseFS(r.templates, name)
+	if err != nil {
+		return nil, err
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return nil, err
+	}
+
+	content := buf.Bytes()
+	if len(content) == 0 || content[len(content)-1] != '\n' {
+		content = append(content, '\n')
+	}
+
+	return content, nil
+}

--- a/internal/codegen/renderer/scala.go
+++ b/internal/codegen/renderer/scala.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"unicode"
 
 	"github.com/galax-io/galaxio-cli/internal/codegen"
 )
@@ -42,7 +41,7 @@ type bodyTemplateData struct {
 }
 
 func buildRequestTemplateData(spec *codegen.Spec, request codegen.Request) actionsRequestTemplateData {
-	name := lowerCamel(request.Name)
+	name := codegen.LowerCamel(request.Name)
 	if name == "" {
 		name = "request"
 	}
@@ -56,7 +55,7 @@ func buildRequestTemplateData(spec *codegen.Spec, request codegen.Request) actio
 
 	bodyFile := ""
 	if request.Body != nil {
-		bodyFile = lowerCamel(request.Name) + ".json"
+		bodyFile = codegen.LowerCamel(request.Name) + ".json"
 		lines = append(lines, fmt.Sprintf(".body(ElFileBody(%q)).asJson", "bodies/"+bodyFile))
 	}
 
@@ -75,7 +74,7 @@ func buildRequestTemplateData(spec *codegen.Spec, request codegen.Request) actio
 func renderParamLines(params []codegen.Param) []string {
 	lines := make([]string, 0, len(params))
 	for _, param := range params {
-		placeholder := scalaPlaceholder(lowerCamel(param.Name))
+		placeholder := scalaPlaceholder(codegen.LowerCamel(param.Name))
 		switch strings.ToLower(param.In) {
 		case "query":
 			lines = append(lines, fmt.Sprintf(".queryParam(%q, %q)", param.Name, placeholder))
@@ -91,7 +90,7 @@ func renderHeaderLines(headers []codegen.Header) []string {
 	for _, header := range headers {
 		value := header.Value
 		if strings.TrimSpace(value) == "" {
-			value = scalaPlaceholder(lowerCamel(header.Name))
+			value = scalaPlaceholder(codegen.LowerCamel(header.Name))
 		}
 		lines = append(lines, fmt.Sprintf(".header(%q, %q)", header.Name, value))
 	}
@@ -136,7 +135,7 @@ func pathParamReplacer(value string) string {
 			end := strings.IndexByte(value[i:], '}')
 			if end > 0 {
 				name := value[i+1 : i+end]
-				builder.WriteString(scalaPlaceholder(lowerCamel(name)))
+				builder.WriteString(scalaPlaceholder(codegen.LowerCamel(name)))
 				i += end
 				continue
 			}
@@ -241,7 +240,7 @@ func appendPath(path []string, part string) []string {
 func flattenPlaceholder(parts []string) string {
 	filtered := make([]string, 0, len(parts))
 	for _, part := range parts {
-		part = lowerCamel(part)
+		part = codegen.LowerCamel(part)
 		if part != "" {
 			filtered = append(filtered, part)
 		}
@@ -268,25 +267,8 @@ func scalaPlaceholder(name string) string {
 	return "${" + name + "}"
 }
 
-func lowerCamel(value string) string {
-	words := splitWords(value)
-	if len(words) == 0 {
-		return ""
-	}
-
-	for i := range words {
-		words[i] = strings.ToLower(words[i])
-	}
-
-	result := words[0]
-	for _, word := range words[1:] {
-		result += strings.ToUpper(word[:1]) + word[1:]
-	}
-	return result
-}
-
 func pascalCase(value string) string {
-	words := splitWords(value)
+	words := codegen.SplitWords(value)
 	if len(words) == 0 {
 		return ""
 	}
@@ -298,41 +280,4 @@ func pascalCase(value string) string {
 		builder.WriteString(lower[1:])
 	}
 	return builder.String()
-}
-
-func splitWords(value string) []string {
-	replacer := strings.NewReplacer("/", " ", "-", " ", "_", " ", ".", " ")
-	value = replacer.Replace(value)
-
-	parts := strings.FieldsFunc(value, func(r rune) bool {
-		return unicode.IsSpace(r) || unicode.IsPunct(r)
-	})
-
-	words := make([]string, 0, len(parts))
-	for _, part := range parts {
-		if part == "" {
-			continue
-		}
-
-		var builder strings.Builder
-		runes := []rune(part)
-		for i, r := range runes {
-			if i > 0 && unicode.IsUpper(r) && (unicode.IsLower(runes[i-1]) || i+1 < len(runes) && unicode.IsLower(runes[i+1])) {
-				words = appendWord(words, builder.String())
-				builder.Reset()
-			}
-			builder.WriteRune(r)
-		}
-		words = appendWord(words, builder.String())
-	}
-
-	return words
-}
-
-func appendWord(words []string, word string) []string {
-	word = strings.TrimSpace(word)
-	if word == "" {
-		return words
-	}
-	return append(words, word)
 }

--- a/internal/codegen/renderer/scala.go
+++ b/internal/codegen/renderer/scala.go
@@ -1,0 +1,338 @@
+package renderer
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"unicode"
+
+	"github.com/galax-io/galaxio-cli/internal/codegen"
+)
+
+type actionsTemplateData struct {
+	Package    string
+	ObjectName string
+	Requests   []actionsRequestTemplateData
+}
+
+type actionsRequestTemplateData struct {
+	Name     string
+	Builder  string
+	BodyFile string
+	Comments []string
+}
+
+type scenarioTemplateData struct {
+	Package      string
+	CasesImport  string
+	ObjectName   string
+	ScenarioName string
+	ExecCalls    []string
+}
+
+type authActionsTemplateData struct {
+	Package string
+	Schemes []codegen.AuthScheme
+}
+
+type bodyTemplateData struct {
+	Body *codegen.BodySchema
+}
+
+func buildRequestTemplateData(spec *codegen.Spec, request codegen.Request) actionsRequestTemplateData {
+	name := lowerCamel(request.Name)
+	if name == "" {
+		name = "request"
+	}
+
+	lines := []string{
+		fmt.Sprintf("http(%q)", requestLabel(request)),
+		fmt.Sprintf(".%s(%q)", strings.ToLower(request.Method), joinURLPath(spec.BasePath, request.Path)),
+	}
+	lines = append(lines, renderParamLines(request.Params)...)
+	lines = append(lines, renderHeaderLines(request.Headers)...)
+
+	bodyFile := ""
+	if request.Body != nil {
+		bodyFile = lowerCamel(request.Name) + ".json"
+		lines = append(lines, fmt.Sprintf(".body(ElFileBody(%q)).asJson", "bodies/"+bodyFile))
+	}
+
+	if statusCode := primaryStatusCode(request.Responses); statusCode != "" {
+		lines = append(lines, fmt.Sprintf(".check(status is %s)", statusCode))
+	}
+
+	return actionsRequestTemplateData{
+		Name:     name,
+		Builder:  strings.Join(lines, "\n    "),
+		BodyFile: bodyFile,
+		Comments: request.Comments,
+	}
+}
+
+func renderParamLines(params []codegen.Param) []string {
+	lines := make([]string, 0, len(params))
+	for _, param := range params {
+		placeholder := scalaPlaceholder(lowerCamel(param.Name))
+		switch strings.ToLower(param.In) {
+		case "query":
+			lines = append(lines, fmt.Sprintf(".queryParam(%q, %q)", param.Name, placeholder))
+		case "formdata":
+			lines = append(lines, fmt.Sprintf(".formParam(%q, %q)", param.Name, placeholder))
+		}
+	}
+	return lines
+}
+
+func renderHeaderLines(headers []codegen.Header) []string {
+	lines := make([]string, 0, len(headers))
+	for _, header := range headers {
+		value := header.Value
+		if strings.TrimSpace(value) == "" {
+			value = scalaPlaceholder(lowerCamel(header.Name))
+		}
+		lines = append(lines, fmt.Sprintf(".header(%q, %q)", header.Name, value))
+	}
+	return lines
+}
+
+func primaryStatusCode(responses []codegen.Response) string {
+	for _, response := range responses {
+		if _, err := strconv.Atoi(response.StatusCode); err == nil {
+			return response.StatusCode
+		}
+	}
+	return ""
+}
+
+func joinURLPath(basePath string, requestPath string) string {
+	basePath = strings.TrimSpace(basePath)
+	requestPath = strings.TrimSpace(requestPath)
+
+	switch {
+	case basePath == "":
+		return rewritePathPlaceholders(requestPath)
+	case requestPath == "":
+		return rewritePathPlaceholders(basePath)
+	default:
+		return rewritePathPlaceholders(strings.TrimRight(basePath, "/") + "/" + strings.TrimLeft(requestPath, "/"))
+	}
+}
+
+func rewritePathPlaceholders(value string) string {
+	return pathParamReplacer(strings.TrimSpace(value))
+}
+
+func pathParamReplacer(value string) string {
+	var builder strings.Builder
+	for i := 0; i < len(value); i++ {
+		if value[i] == '{' {
+			if i > 0 && value[i-1] == '$' {
+				builder.WriteByte(value[i])
+				continue
+			}
+			end := strings.IndexByte(value[i:], '}')
+			if end > 0 {
+				name := value[i+1 : i+end]
+				builder.WriteString(scalaPlaceholder(lowerCamel(name)))
+				i += end
+				continue
+			}
+		}
+		builder.WriteByte(value[i])
+	}
+	return builder.String()
+}
+
+func renderBodyTemplate(body *codegen.BodySchema) string {
+	if body == nil {
+		return "{}"
+	}
+	if strings.TrimSpace(body.Raw) != "" {
+		return renderRawBody(body.Raw)
+	}
+	return renderBodyValue(body, nil, 0)
+}
+
+func renderRawBody(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return "{}"
+	}
+
+	var compact bytes.Buffer
+	if err := json.Compact(&compact, []byte(trimmed)); err != nil {
+		return trimmed
+	}
+
+	var pretty bytes.Buffer
+	if err := json.Indent(&pretty, compact.Bytes(), "", "  "); err != nil {
+		return compact.String()
+	}
+
+	return pretty.String()
+}
+
+func renderBodyValue(schema *codegen.BodySchema, path []string, indent int) string {
+	if schema == nil {
+		return "null"
+	}
+
+	switch strings.ToLower(schema.Type) {
+	case "object":
+		return renderBodyObject(schema, path, indent)
+	case "array":
+		return renderBodyArray(schema, path, indent)
+	case "integer", "number":
+		return scalaPlaceholder(flattenPlaceholder(path))
+	case "boolean":
+		return scalaPlaceholder(flattenPlaceholder(path))
+	default:
+		return fmt.Sprintf("%q", scalaPlaceholder(flattenPlaceholder(path)))
+	}
+}
+
+func renderBodyObject(schema *codegen.BodySchema, path []string, indent int) string {
+	if len(schema.Fields) == 0 {
+		return "{}"
+	}
+
+	lines := make([]string, 0, len(schema.Fields)+2)
+	lines = append(lines, "{")
+	for i, field := range schema.Fields {
+		fieldPath := appendPath(path, field.Name)
+		value := renderBodyValue(&field, fieldPath, indent+2)
+		line := strings.Repeat(" ", indent+2) + fmt.Sprintf("%q: %s", field.Name, value)
+		if i < len(schema.Fields)-1 {
+			line += ","
+		}
+		lines = append(lines, line)
+	}
+	lines = append(lines, strings.Repeat(" ", indent)+"}")
+	return strings.Join(lines, "\n")
+}
+
+func renderBodyArray(schema *codegen.BodySchema, path []string, indent int) string {
+	if schema.Items == nil {
+		return "[]"
+	}
+
+	itemValue := renderBodyValue(schema.Items, appendPath(path, "item"), indent+2)
+	lines := []string{
+		"[",
+		strings.Repeat(" ", indent+2) + itemValue,
+		strings.Repeat(" ", indent) + "]",
+	}
+	return strings.Join(lines, "\n")
+}
+
+func appendPath(path []string, part string) []string {
+	part = strings.TrimSpace(part)
+	if part == "" {
+		return append([]string{}, path...)
+	}
+	next := append([]string{}, path...)
+	next = append(next, part)
+	return next
+}
+
+func flattenPlaceholder(parts []string) string {
+	filtered := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = lowerCamel(part)
+		if part != "" {
+			filtered = append(filtered, part)
+		}
+	}
+	if len(filtered) == 0 {
+		return "value"
+	}
+
+	result := filtered[0]
+	for _, part := range filtered[1:] {
+		result += strings.ToUpper(part[:1]) + part[1:]
+	}
+	return result
+}
+
+func requestLabel(request codegen.Request) string {
+	return strings.TrimSpace(request.Method) + " " + strings.TrimSpace(request.Path)
+}
+
+func scalaPlaceholder(name string) string {
+	if strings.TrimSpace(name) == "" {
+		name = "value"
+	}
+	return "${" + name + "}"
+}
+
+func lowerCamel(value string) string {
+	words := splitWords(value)
+	if len(words) == 0 {
+		return ""
+	}
+
+	for i := range words {
+		words[i] = strings.ToLower(words[i])
+	}
+
+	result := words[0]
+	for _, word := range words[1:] {
+		result += strings.ToUpper(word[:1]) + word[1:]
+	}
+	return result
+}
+
+func pascalCase(value string) string {
+	words := splitWords(value)
+	if len(words) == 0 {
+		return ""
+	}
+
+	var builder strings.Builder
+	for _, word := range words {
+		lower := strings.ToLower(word)
+		builder.WriteString(strings.ToUpper(lower[:1]))
+		builder.WriteString(lower[1:])
+	}
+	return builder.String()
+}
+
+func splitWords(value string) []string {
+	replacer := strings.NewReplacer("/", " ", "-", " ", "_", " ", ".", " ")
+	value = replacer.Replace(value)
+
+	parts := strings.FieldsFunc(value, func(r rune) bool {
+		return unicode.IsSpace(r) || unicode.IsPunct(r)
+	})
+
+	words := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if part == "" {
+			continue
+		}
+
+		var builder strings.Builder
+		runes := []rune(part)
+		for i, r := range runes {
+			if i > 0 && unicode.IsUpper(r) && (unicode.IsLower(runes[i-1]) || i+1 < len(runes) && unicode.IsLower(runes[i+1])) {
+				words = appendWord(words, builder.String())
+				builder.Reset()
+			}
+			builder.WriteRune(r)
+		}
+		words = appendWord(words, builder.String())
+	}
+
+	return words
+}
+
+func appendWord(words []string, word string) []string {
+	word = strings.TrimSpace(word)
+	if word == "" {
+		return words
+	}
+	return append(words, word)
+}

--- a/internal/codegen/renderer/scala_test.go
+++ b/internal/codegen/renderer/scala_test.go
@@ -1,0 +1,180 @@
+package renderer
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/galax-io/galaxio-cli/internal/codegen"
+	"github.com/galax-io/galaxio-cli/internal/codegen/parser"
+)
+
+func TestRendererRenderMatchesGoldenFiles(t *testing.T) {
+	t.Parallel()
+
+	renderer := NewRenderer()
+	files, err := renderer.Render(testSpec(), RenderOptions{Package: "org.galaxio.performance"})
+	if err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+
+	wantFiles := map[string]string{
+		"cases/AuthActions.scala":          "golden/cases/AuthActions.scala",
+		"cases/PetAdminActions.scala":      "golden/cases/PetAdminActions.scala",
+		"resources/bodies/createPet.json":  "golden/resources/bodies/createPet.json",
+		"scenarios/PetAdminScenario.scala": "golden/scenarios/PetAdminScenario.scala",
+	}
+
+	if len(files) != len(wantFiles) {
+		t.Fatalf("expected %d files, got %d", len(wantFiles), len(files))
+	}
+
+	got := make(map[string]string, len(files))
+	for _, file := range files {
+		got[file.Path] = string(file.Content)
+	}
+
+	for path, goldenPath := range wantFiles {
+		payload, err := os.ReadFile(filepath.Join("testdata", goldenPath))
+		if err != nil {
+			t.Fatalf("ReadFile(%q) error = %v", goldenPath, err)
+		}
+
+		if got[path] != string(payload) {
+			t.Fatalf("unexpected output for %s\nwant:\n%s\ngot:\n%s", path, payload, got[path])
+		}
+	}
+}
+
+func TestRendererRenderFromSwaggerFixtureProducesScalaOutputs(t *testing.T) {
+	t.Parallel()
+
+	fixture, err := os.ReadFile(filepath.Join("..", "testdata", "petstore-swagger2.json"))
+	if err != nil {
+		t.Fatalf("ReadFile(fixture) error = %v", err)
+	}
+
+	spec, err := parser.NewSwaggerParser().Parse(context.Background(), fixture)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	files, err := NewRenderer().Render(spec, RenderOptions{Package: "org.example.petstore"})
+	if err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+
+	for _, wantPath := range []string{
+		"cases/AuthActions.scala",
+		"cases/PetActions.scala",
+		"cases/StoreActions.scala",
+		"cases/UserActions.scala",
+		"scenarios/PetScenario.scala",
+		"scenarios/StoreScenario.scala",
+		"scenarios/UserScenario.scala",
+		"resources/bodies/addPet.json",
+		"resources/bodies/updatePet.json",
+		"resources/bodies/placeOrder.json",
+		"resources/bodies/updateUser.json",
+		"resources/bodies/createUsersWithArrayInput.json",
+		"resources/bodies/createUsersWithListInput.json",
+		"resources/bodies/createUser.json",
+	} {
+		assertHasFileContaining(t, files, wantPath, "")
+	}
+
+	assertHasFileContaining(t, files, "cases/PetActions.scala", "package org.example.petstore.cases")
+	assertHasFileContaining(t, files, "cases/PetActions.scala", `.body(ElFileBody("bodies/addPet.json")).asJson`)
+	assertHasFileContaining(t, files, "scenarios/UserScenario.scala", "object UserScenario")
+	assertHasFileContaining(t, files, "resources/bodies/placeOrder.json", `"shipDate": "${shipDate}"`)
+	assertHasFileContaining(t, files, "resources/bodies/createUsersWithListInput.json", `"username": "${itemUsername}"`)
+	assertHasFileContaining(t, files, "cases/AuthActions.scala", "Suggested schemes from the source spec")
+}
+
+func TestRendererRenderRejectsInvalidInputs(t *testing.T) {
+	t.Parallel()
+
+	renderer := NewRenderer()
+	if _, err := renderer.Render(nil, RenderOptions{Package: "org.example"}); err == nil {
+		t.Fatal("expected nil spec to fail")
+	}
+	if _, err := renderer.Render(&codegen.Spec{}, RenderOptions{}); err == nil {
+		t.Fatal("expected empty package to fail")
+	}
+}
+
+func assertHasFileContaining(t *testing.T, files []OutputFile, path string, want string) {
+	t.Helper()
+
+	for _, file := range files {
+		if file.Path == path {
+			if !strings.Contains(string(file.Content), want) {
+				t.Fatalf("expected %s to contain %q, got:\n%s", path, want, file.Content)
+			}
+			return
+		}
+	}
+
+	t.Fatalf("expected file %s to be rendered", path)
+}
+
+func testSpec() *codegen.Spec {
+	return &codegen.Spec{
+		BasePath: "/api/v1",
+		AuthSchemes: []codegen.AuthScheme{
+			{
+				Key:      "bearerAuth",
+				Type:     "bearer",
+				Name:     "Authorization",
+				Location: "header",
+			},
+		},
+		Groups: []codegen.Group{
+			{
+				Name: "pet-admin",
+				Requests: []codegen.Request{
+					{
+						Method: "POST",
+						Path:   "/pets/{petId}",
+						Name:   "createPet",
+						Headers: []codegen.Header{
+							{Name: "Authorization"},
+						},
+						Params: []codegen.Param{
+							{Name: "petId", In: "path", Type: "string", Required: true},
+							{Name: "trace-id", In: "query", Type: "string"},
+						},
+						Body: &codegen.BodySchema{
+							Type: "object",
+							Fields: []codegen.BodySchema{
+								{Name: "name", Type: "string", Required: true},
+								{
+									Name: "category",
+									Type: "object",
+									Fields: []codegen.BodySchema{
+										{Name: "id", Type: "integer"},
+										{Name: "name", Type: "string"},
+									},
+								},
+								{
+									Name: "tags",
+									Type: "array",
+									Items: &codegen.BodySchema{
+										Type: "object",
+										Fields: []codegen.BodySchema{
+											{Name: "id", Type: "integer"},
+											{Name: "name", Type: "string"},
+										},
+									},
+								},
+							},
+						},
+						Responses: []codegen.Response{{StatusCode: "201"}},
+					},
+				},
+			},
+		},
+	}
+}

--- a/internal/codegen/renderer/testdata/golden/cases/AuthActions.scala
+++ b/internal/codegen/renderer/testdata/golden/cases/AuthActions.scala
@@ -1,0 +1,11 @@
+package org.galaxio.performance.cases
+
+import io.gatling.core.Predef._
+
+object AuthActions {
+  // TODO: replace this placeholder with project-specific authentication calls.
+  // Suggested schemes from the source spec:
+  // - bearerAuth (type=bearer, name=Authorization, in=header)
+  // Example saveAs pattern:
+  // exec(session => session.set("accessToken", "replace-me"))
+}

--- a/internal/codegen/renderer/testdata/golden/cases/PetAdminActions.scala
+++ b/internal/codegen/renderer/testdata/golden/cases/PetAdminActions.scala
@@ -1,0 +1,13 @@
+package org.galaxio.performance.cases
+
+import io.gatling.http.Predef._
+import io.gatling.core.Predef._
+
+object PetAdminActions {
+  val createPet = http("POST /pets/{petId}")
+    .post("/api/v1/pets/${petId}")
+    .queryParam("trace-id", "${traceId}")
+    .header("Authorization", "${authorization}")
+    .body(ElFileBody("bodies/createPet.json")).asJson
+    .check(status is 201)
+}

--- a/internal/codegen/renderer/testdata/golden/resources/bodies/createPet.json
+++ b/internal/codegen/renderer/testdata/golden/resources/bodies/createPet.json
@@ -1,0 +1,13 @@
+{
+  "name": "${name}",
+  "category": {
+    "id": ${categoryId},
+    "name": "${categoryName}"
+  },
+  "tags": [
+    {
+      "id": ${tagsItemId},
+      "name": "${tagsItemName}"
+    }
+  ]
+}

--- a/internal/codegen/renderer/testdata/golden/scenarios/PetAdminScenario.scala
+++ b/internal/codegen/renderer/testdata/golden/scenarios/PetAdminScenario.scala
@@ -1,0 +1,16 @@
+package org.galaxio.performance.scenarios
+
+import io.gatling.core.Predef._
+import io.gatling.core.structure.ScenarioBuilder
+import org.galaxio.performance.cases._
+
+object PetAdminScenario {
+  def apply(): ScenarioBuilder = new PetAdminScenario().scn
+}
+
+class PetAdminScenario {
+
+  val scn: ScenarioBuilder = scenario("PetAdmin Scenario")
+    .exec(PetAdminActions.createPet)
+
+}

--- a/internal/codegen/templates/embed.go
+++ b/internal/codegen/templates/embed.go
@@ -1,0 +1,8 @@
+package templates
+
+import "embed"
+
+// Files contains embedded code generation templates.
+//
+//go:embed scala-sbt/*.tmpl
+var Files embed.FS

--- a/internal/codegen/templates/scala-sbt/actions.scala.tmpl
+++ b/internal/codegen/templates/scala-sbt/actions.scala.tmpl
@@ -1,0 +1,13 @@
+package {{ .Package }}
+
+import io.gatling.http.Predef._
+import io.gatling.core.Predef._
+
+object {{ .ObjectName }} {
+{{- range .Requests }}
+{{- range .Comments }}
+  // {{ . }}
+{{- end }}
+  val {{ .Name }} = {{ .Builder }}
+{{- end }}
+}

--- a/internal/codegen/templates/scala-sbt/auth_actions.scala.tmpl
+++ b/internal/codegen/templates/scala-sbt/auth_actions.scala.tmpl
@@ -1,0 +1,13 @@
+package {{ .Package }}
+
+import io.gatling.core.Predef._
+
+object AuthActions {
+  // TODO: replace this placeholder with project-specific authentication calls.
+  // Suggested schemes from the source spec:
+{{- range .Schemes }}
+  // - {{ .Key }} (type={{ .Type }}, name={{ .Name }}, in={{ .Location }})
+{{- end }}
+  // Example saveAs pattern:
+  // exec(session => session.set("accessToken", "replace-me"))
+}

--- a/internal/codegen/templates/scala-sbt/body.json.tmpl
+++ b/internal/codegen/templates/scala-sbt/body.json.tmpl
@@ -1,0 +1,1 @@
+{{ renderBody .Body }}

--- a/internal/codegen/templates/scala-sbt/scenario.scala.tmpl
+++ b/internal/codegen/templates/scala-sbt/scenario.scala.tmpl
@@ -1,0 +1,18 @@
+package {{ .Package }}
+
+import io.gatling.core.Predef._
+import io.gatling.core.structure.ScenarioBuilder
+import {{ .CasesImport }}
+
+object {{ .ObjectName }} {
+  def apply(): ScenarioBuilder = new {{ .ObjectName }}().scn
+}
+
+class {{ .ObjectName }} {
+
+  val scn: ScenarioBuilder = scenario("{{ .ScenarioName }}")
+{{- range .ExecCalls }}
+    .exec({{ . }})
+{{- end }}
+
+}

--- a/internal/codegen/testdata/api-with-examples-openapi3.yaml
+++ b/internal/codegen/testdata/api-with-examples-openapi3.yaml
@@ -1,0 +1,73 @@
+openapi: 3.0.0
+info:
+  title: Simple API overview
+  version: 2.0.0
+paths:
+  /:
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+                      - status: EXPERIMENTAL
+                        updated: "2013-07-23T11:33:21Z"
+                        id: v3.0
+                        links:
+                          - href: http://127.0.0.1:8774/v3/
+                            rel: self
+        "300":
+          description: 300 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+  /v2:
+    get:
+      operationId: getVersionDetailsv2
+      summary: Show API version details
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    version:
+                      status: CURRENT
+                      updated: "2011-01-21T11:33:21Z"
+                      media-types:
+                        - base: application/xml
+                          type: application/vnd.openstack.compute+xml;version=2
+                        - base: application/json
+                          type: application/vnd.openstack.compute+json;version=2
+                      id: v2.0
+        "203":
+          description: 203 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    version:
+                      status: CURRENT
+                      updated: "2011-01-21T11:33:21Z"
+                      id: v2.0

--- a/internal/codegen/testdata/har-application-json.json
+++ b/internal/codegen/testdata/har-application-json.json
@@ -1,0 +1,67 @@
+{
+  "log": {
+    "entries": [
+      {
+        "startedDateTime": "2021-07-09T23:28:52.627Z",
+        "time": 85,
+        "request": {
+          "method": "POST",
+          "url": "https://httpbin.org/post",
+          "httpVersion": "HTTP/1.1",
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/json"
+            }
+          ],
+          "queryString": [],
+          "postData": {
+            "mimeType": "application/json",
+            "text": "{\"number\":1,\"string\":\"f\\\"oo\",\"arr\":[1,2,3],\"nested\":{\"a\":\"b\"},\"arr_mix\":[1,\"a\",{\"arr_mix_nested\":{}}],\"boolean\":false}"
+          },
+          "bodySize": -1,
+          "headersSize": -1
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "HTTP/1.1",
+          "headers": [
+            {
+              "name": "Accept",
+              "value": "*/*"
+            },
+            {
+              "name": "Accept-Encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "name": "Content-Length",
+              "value": "118"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            },
+            {
+              "name": "Host",
+              "value": "httpbin.org"
+            },
+            {
+              "name": "User-Agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            }
+          ],
+          "content": {
+            "size": 597,
+            "mimeType": "application/json",
+            "text": "{\"args\":{},\"data\":\"{\\\"number\\\":1,\\\"string\\\":\\\"f\\\\\\\"oo\\\",\\\"arr\\\":[1,2,3],\\\"nested\\\":{\\\"a\\\":\\\"b\\\"},\\\"arr_mix\\\":[1,\\\"a\\\",{\\\"arr_mix_nested\\\":{}}],\\\"boolean\\\":false}\",\"files\":{},\"form\":{},\"headers\":{\"Accept\":\"*/*\",\"Accept-Encoding\":\"gzip,deflate\",\"Content-Length\":\"118\",\"Content-Type\":\"application/json\",\"Host\":\"httpbin.org\",\"User-Agent\":\"node-fetch/1.0 (+https://github.com/bitinn/node-fetch)\"},\"json\":{\"arr\":[1,2,3],\"arr_mix\":[1,\"a\",{\"arr_mix_nested\":{}}],\"boolean\":false,\"nested\":{\"a\":\"b\"},\"number\":1,\"string\":\"f\\\"oo\"},\"origin\":\"127.0.0.1\",\"url\":\"https://httpbin.org/post\"}"
+          },
+          "headersSize": -1,
+          "bodySize": -1
+        }
+      }
+    ]
+  }
+}

--- a/internal/codegen/testdata/har-cookies.json
+++ b/internal/codegen/testdata/har-cookies.json
@@ -1,0 +1,51 @@
+{
+  "log": {
+    "entries": [
+      {
+        "startedDateTime": "2021-07-09T23:28:52.627Z",
+        "time": 85,
+        "request": {
+          "method": "GET",
+          "url": "https://httpbin.org/cookies",
+          "httpVersion": "HTTP/1.1",
+          "cookies": [
+            {
+              "name": "foo",
+              "value": "bar"
+            },
+            {
+              "name": "bar",
+              "value": "baz"
+            }
+          ],
+          "headers": [],
+          "queryString": [],
+          "bodySize": -1,
+          "headersSize": -1
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "HTTP/1.1",
+          "headers": [
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            },
+            {
+              "name": "Content-Length",
+              "value": "59"
+            }
+          ],
+          "content": {
+            "size": 59,
+            "mimeType": "application/json",
+            "text": "{\"cookies\":{\"bar\":\"baz\",\"foo\":\"bar\"}}"
+          },
+          "headersSize": -1,
+          "bodySize": -1
+        }
+      }
+    ]
+  }
+}

--- a/internal/codegen/testdata/har-headers.json
+++ b/internal/codegen/testdata/har-headers.json
@@ -1,0 +1,63 @@
+{
+  "log": {
+    "entries": [
+      {
+        "startedDateTime": "2021-07-09T23:28:52.627Z",
+        "time": 85,
+        "request": {
+          "method": "GET",
+          "url": "https://httpbin.org/get",
+          "httpVersion": "HTTP/1.1",
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "x-foo",
+              "value": "Bar"
+            }
+          ],
+          "queryString": [],
+          "bodySize": -1,
+          "headersSize": -1
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "HTTP/1.1",
+          "headers": [
+            {
+              "name": "Accept",
+              "value": "application/json"
+            },
+            {
+              "name": "Accept-Encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "name": "Host",
+              "value": "httpbin.org"
+            },
+            {
+              "name": "User-Agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "name": "X-Foo",
+              "value": "Bar"
+            }
+          ],
+          "content": {
+            "size": 473,
+            "mimeType": "application/json",
+            "text": "{\"args\":{},\"headers\":{\"Accept\":\"application/json\",\"Accept-Encoding\":\"gzip,deflate\",\"Host\":\"httpbin.org\",\"User-Agent\":\"node-fetch/1.0 (+https://github.com/bitinn/node-fetch)\",\"X-Foo\":\"Bar\"},\"origin\":\"127.0.0.1\",\"url\":\"https://httpbin.org/get\"}"
+          },
+          "headersSize": -1,
+          "bodySize": -1
+        }
+      }
+    ]
+  }
+}

--- a/internal/codegen/testdata/har-query-encoded.json
+++ b/internal/codegen/testdata/har-query-encoded.json
@@ -1,0 +1,71 @@
+{
+  "log": {
+    "entries": [
+      {
+        "startedDateTime": "2021-07-09T23:28:52.627Z",
+        "time": 85,
+        "request": {
+          "method": "GET",
+          "url": "https://httpbin.org/anything",
+          "httpVersion": "HTTP/1.1",
+          "cookies": [],
+          "headers": [],
+          "queryString": [
+            {
+              "name": "stringPound",
+              "value": "something%26nothing%3Dtrue"
+            },
+            {
+              "name": "stringHash",
+              "value": "hash%23data"
+            },
+            {
+              "name": "stringArray",
+              "value": "where%5B4%5D%3D10"
+            },
+            {
+              "name": "stringWeird",
+              "value": "properties%5B%22%24email%22%5D%20%3D%3D%20%22testing%22"
+            },
+            {
+              "name": "array",
+              "value": "something%26nothing%3Dtrue&array=nothing%26something%3Dfalse&array=another%20item"
+            }
+          ],
+          "bodySize": -1,
+          "headersSize": 0
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "HTTP/1.1",
+          "headers": [
+            {
+              "name": "Accept",
+              "value": "*/*"
+            },
+            {
+              "name": "Accept-Encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "name": "Host",
+              "value": "httpbin.org"
+            },
+            {
+              "name": "User-Agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            }
+          ],
+          "content": {
+            "size": 495,
+            "mimeType": "application/json",
+            "text": "{\"args\":{\"array\":[\"something&nothing=true\",\"nothing&something=false\",\"another item\"],\"stringArray\":\"where[4]=10\",\"stringHash\":\"hash#data\",\"stringPound\":\"something&nothing=true\",\"stringWeird\":\"properties[\\\"$email\\\"] == \\\"testing\\\"\"},\"data\":\"\",\"files\":{},\"form\":{},\"headers\":{\"Accept\":\"*/*\",\"Accept-Encoding\":\"gzip,deflate\",\"Host\":\"httpbin.org\",\"User-Agent\":\"node-fetch/1.0 (+https://github.com/bitinn/node-fetch)\"},\"json\":null,\"method\":\"GET\",\"origin\":\"127.0.0.1\",\"url\":\"https://httpbin.org/anything?stringPound=something%26nothing%3Dtrue&stringHash=hash%23data&stringArray=where[4]%3D10&stringWeird=properties[\\\"%24email\\\"] %3D%3D \\\"testing\\\"&array=something%26nothing%3Dtrue&array=nothing%26something%3Dfalse&array=another item\"}"
+          },
+          "headersSize": -1,
+          "bodySize": -1
+        }
+      }
+    ]
+  }
+}

--- a/internal/codegen/testdata/har-short.json
+++ b/internal/codegen/testdata/har-short.json
@@ -1,0 +1,50 @@
+{
+  "log": {
+    "entries": [
+      {
+        "startedDateTime": "2021-07-09T23:28:52.627Z",
+        "time": 85,
+        "request": {
+          "method": "GET",
+          "url": "https://httpbin.org/get",
+          "httpVersion": "HTTP/1.1",
+          "cookies": [],
+          "headers": [],
+          "queryString": [],
+          "bodySize": -1,
+          "headersSize": -1
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "HTTP/1.1",
+          "headers": [
+            {
+              "name": "Accept",
+              "value": "*/*"
+            },
+            {
+              "name": "Accept-Encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "name": "Host",
+              "value": "httpbin.org"
+            },
+            {
+              "name": "User-Agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            }
+          ],
+          "content": {
+            "size": 404,
+            "mimeType": "application/json",
+            "text": "{\"args\":{},\"headers\":{\"Accept\":\"*/*\",\"Accept-Encoding\":\"gzip,deflate\",\"Host\":\"httpbin.org\",\"User-Agent\":\"node-fetch/1.0 (+https://github.com/bitinn/node-fetch)\"},\"origin\":\"127.0.0.1\",\"url\":\"https://httpbin.org/get\"}"
+          },
+          "headersSize": -1,
+          "bodySize": -1
+        }
+      }
+    ]
+  }
+}

--- a/internal/codegen/testdata/har-static-asset.json
+++ b/internal/codegen/testdata/har-static-asset.json
@@ -1,0 +1,38 @@
+{
+  "log": {
+    "entries": [
+      {
+        "startedDateTime": "2026-05-21T10:00:03.000Z",
+        "time": 14,
+        "request": {
+          "method": "GET",
+          "url": "https://httpbin.org/assets/app.js",
+          "httpVersion": "HTTP/1.1",
+          "cookies": [],
+          "headers": [
+            {
+              "name": "Accept",
+              "value": "*/*"
+            }
+          ],
+          "queryString": [],
+          "bodySize": -1,
+          "headersSize": -1
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "HTTP/1.1",
+          "headers": [],
+          "content": {
+            "size": 17,
+            "mimeType": "application/javascript",
+            "text": "console.log('x')"
+          },
+          "headersSize": -1,
+          "bodySize": -1
+        }
+      }
+    ]
+  }
+}

--- a/internal/codegen/testdata/petstore-openapi3.yaml
+++ b/internal/codegen/testdata/petstore-openapi3.yaml
@@ -1,0 +1,77 @@
+openapi: 3.0.3
+info:
+  title: Petstore OpenAPI 3
+  version: 3.0.0
+servers:
+  - url: https://example.com/api/v3
+paths:
+  /pets:
+    get:
+      tags: [pets]
+      summary: List pets
+      operationId: listPets
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "200":
+          description: OK
+    post:
+      tags: [pets]
+      summary: Create pet
+      operationId: createPet
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PetInput"
+      responses:
+        "201":
+          description: Created
+  /pets/{petId}:
+    delete:
+      tags: [pets]
+      summary: Delete pet
+      operationId: deletePet
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: X-Trace-Id
+          in: header
+          required: false
+          schema:
+            type: string
+      responses:
+        "204":
+          description: Deleted
+components:
+  schemas:
+    PetInput:
+      type: object
+      required: [name]
+      properties:
+        name:
+          type: string
+        tag:
+          type: string
+        metadata:
+          type: object
+          properties:
+            nickname:
+              type: string
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      name: X-API-Key
+      in: header
+    BearerAuth:
+      type: http
+      scheme: bearer

--- a/internal/codegen/testdata/petstore-openapi31.yaml
+++ b/internal/codegen/testdata/petstore-openapi31.yaml
@@ -1,0 +1,51 @@
+openapi: 3.1.0
+info:
+  title: Petstore OpenAPI 3.1
+  version: 3.1.0
+servers:
+  - url: https://example.com/platform/v31/
+paths:
+  /pets:
+    post:
+      tags: [pets]
+      summary: Upsert pet
+      operationId: upsertPet
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PetPatch"
+      responses:
+        "200":
+          description: Updated
+webhooks:
+  petUpdated:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        "202":
+          description: Accepted
+components:
+  schemas:
+    PetPatch:
+      type: object
+      required: [id]
+      properties:
+        id:
+          type: string
+        nickname:
+          type:
+            - string
+            - "null"
+        aliases:
+          type: array
+          items:
+            type:
+              - string
+              - "null"

--- a/internal/codegen/testdata/sample-collection.json
+++ b/internal/codegen/testdata/sample-collection.json
@@ -1,0 +1,158 @@
+{
+  "info": {
+    "_postman_id": "d3c5347f-bc0d-4c14-92bf-abc123",
+    "name": "Orders API Collection",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "auth": {
+    "type": "bearer",
+    "bearer": [
+      {
+        "key": "token",
+        "value": "{{accessToken}}",
+        "type": "string"
+      }
+    ]
+  },
+  "variable": [
+    {
+      "key": "baseUrl",
+      "value": "https://api.example.com"
+    },
+    {
+      "key": "traceId",
+      "value": "trace-123"
+    }
+  ],
+  "item": [
+    {
+      "name": "Orders",
+      "auth": {
+        "type": "apikey",
+        "apikey": [
+          {
+            "key": "key",
+            "value": "X-API-Key",
+            "type": "string"
+          },
+          {
+            "key": "value",
+            "value": "{{apiKey}}",
+            "type": "string"
+          },
+          {
+            "key": "in",
+            "value": "header",
+            "type": "string"
+          }
+        ]
+      },
+      "event": [
+        {
+          "listen": "prerequest",
+          "script": {
+            "exec": [
+              "pm.variables.set(\"traceId\", \"trace-456\");",
+              "console.log(\"prepare request\");"
+            ]
+          }
+        }
+      ],
+      "item": [
+        {
+          "name": "Create order",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "X-Trace-Id",
+                "value": "{{traceId}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"sku\": \"{{sku}}\",\n  \"quantity\": {{quantity}}\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/orders",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "orders"
+              ]
+            }
+          },
+          "response": [
+            {
+              "name": "Created",
+              "code": 201,
+              "status": "Created"
+            }
+          ]
+        },
+        {
+          "name": "Get order",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/orders/{{orderId}}?expand={{expand}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "orders",
+                "{{orderId}}"
+              ],
+              "query": [
+                {
+                  "key": "expand",
+                  "value": "{{expand}}"
+                }
+              ]
+            }
+          },
+          "response": [
+            {
+              "name": "OK",
+              "code": 200,
+              "status": "OK"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Health check",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{baseUrl}}/health",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "health"
+          ]
+        }
+      },
+      "response": [
+        {
+          "name": "OK",
+          "code": 200,
+          "status": "OK"
+        }
+      ]
+    }
+  ]
+}

--- a/internal/codegen/testdata/webhook-example-openapi31.yaml
+++ b/internal/codegen/testdata/webhook-example-openapi31.yaml
@@ -1,0 +1,31 @@
+openapi: 3.1.0
+info:
+  title: Webhook Example
+  version: 1.0.0
+webhooks:
+  newPet:
+    post:
+      requestBody:
+        description: Information about a new pet in the system
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Pet"
+      responses:
+        "200":
+          description: Return a 200 status to indicate that the data was received successfully
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        tag:
+          type: string

--- a/internal/codegen/testdata/zitadel.postman_collection.json
+++ b/internal/codegen/testdata/zitadel.postman_collection.json
@@ -1,0 +1,462 @@
+{
+  "info": {
+    "_postman_id": "8a9b32cd-04ce-4138-a422-5aa313bc7f51",
+    "name": "ZITADEL with Postman",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "_exporter_id": "32877280"
+  },
+  "item": [
+    {
+      "name": "Add ZITADEL Project",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "let response_body = pm.response.json();",
+              "pm.environment.set(\"project_id\", response_body.id); "
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "auth": {
+          "type": "bearer",
+          "bearer": [
+            {
+              "key": "token",
+              "value": "{{service_user_PAT}}",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json",
+            "type": "text"
+          },
+          {
+            "key": "Accept",
+            "value": "application/json",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n \"name\": \"MyPostmanProject\",\n \"projectRoleAssertion\": true,\n \"projectRoleCheck\": true,\n \"hasProjectCheck\": true,\n \"privateLabelingSetting\": \"PRIVATE_LABELING_SETTING_UNSPECIFIED\"\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{your_zitadel_domain}}/management/v1/projects",
+          "host": [
+            "{{your_zitadel_domain}}"
+          ],
+          "path": [
+            "management",
+            "v1",
+            "projects"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Add ZITADEL WebApp - PKCE",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "let response_body = pm.response.json();",
+              "pm.environment.set(\"web_app_client_id\", response_body.clientId); "
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "auth": {
+          "type": "bearer",
+          "bearer": [
+            {
+              "key": "token",
+              "value": "{{service_user_PAT}}",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json",
+            "type": "text"
+          },
+          {
+            "key": "Accept",
+            "value": "application/json",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n \"name\": \"MyOIDCWebApp\",\n \"redirectUris\": [\n \"https://oauth.pstmn.io/v1/browser-callback\"\n ],\n \"responseTypes\": [\n \"OIDC_RESPONSE_TYPE_CODE\"\n ],\n \"grantTypes\": [\n \"OIDC_GRANT_TYPE_AUTHORIZATION_PKCE\"\n ],\n \"appType\": \"OIDC_APP_TYPE_WEB\",\n \"authMethodType\": \"OIDC_AUTH_METHOD_TYPE_NONE\",\n \"version\": \"OIDC_VERSION_1_0\",\n \"devMode\": true,\n \"accessTokenType\": \"OIDC_TOKEN_TYPE_BEARER\",\n \"accessTokenRoleAssertion\": true,\n \"idTokenRoleAssertion\": true,\n \"idTokenUserinfoAssertion\": true,\n \"clockSkew\": \"1s\",\n \"skipNativeAppSuccessPage\": true\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{your_zitadel_domain}}/management/v1/projects/{{project_id}}/apps/oidc",
+          "host": [
+            "{{your_zitadel_domain}}"
+          ],
+          "path": [
+            "management",
+            "v1",
+            "projects",
+            "{{project_id}}",
+            "apps",
+            "oidc"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Add ZITADEL API",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              ""
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "auth": {
+          "type": "bearer",
+          "bearer": [
+            {
+              "key": "token",
+              "value": "{{service_user_PAT}}",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json",
+            "type": "text"
+          },
+          {
+            "key": "Accept",
+            "value": "application/json",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n \"name\": \"MyAPIApp\",\n \"authMethodType\": \"API_AUTH_METHOD_TYPE_BASIC\"\n}\n",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{your_zitadel_domain}}/management/v1/projects/{{project_id}}/apps/api",
+          "host": [
+            "{{your_zitadel_domain}}"
+          ],
+          "path": [
+            "management",
+            "v1",
+            "projects",
+            "{{project_id}}",
+            "apps",
+            "api"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Add ZITADEL User (Human)",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              ""
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "auth": {
+          "type": "bearer",
+          "bearer": [
+            {
+              "key": "token",
+              "value": "{{service_user_PAT}}",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json",
+            "type": "text"
+          },
+          {
+            "key": "Accept",
+            "value": "application/json",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n \"userName\": \"minnie-mouse\",\n \"profile\": {\n \"firstName\": \"Minnie\",\n \"lastName\": \"Mouse\",\n \"nickName\": \"Mini\",\n \"displayName\": \"Minnie Mouse\",\n \"preferredLanguage\": \"en\",\n \"gender\": \"GENDER_FEMALE\"\n },\n \"email\": {\n \"email\": \"minnie@mouse.com\",\n \"isEmailVerified\": true\n },\n \"phone\": {\n \"phone\": \"+41 71 000 00 00\",\n \"isPhoneVerified\": true\n },\n \"hashedPassword\": {\n \"value\": \"$2a$12$k0LsiR40ZNcMxbyD80g5nebjB9R0/VqilwfFLLr6m/XTOc9WRf8Om\"\n },\n \"passwordChangeRequired\": true,\n \"requestPasswordlessRegistration\": true,\n \"otpCode\": \"string\"\n}\n",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{your_zitadel_domain}}/management/v1/users/human/_import",
+          "host": [
+            "{{your_zitadel_domain}}"
+          ],
+          "path": [
+            "management",
+            "v1",
+            "users",
+            "human",
+            "_import"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Login User and Call Userinfo Endpoint",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "if (pm.request.headers.has(\"Authorization\")) {",
+              " let authHeader = pm.request.headers.get(\"Authorization\");",
+              " let accessToken = authHeader.split(\" \")[1]; // Assuming the format is \"Bearer \"",
+              " pm.environment.set(\"access_token\", accessToken);",
+              "}",
+              "",
+              "",
+              "",
+              ""
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "auth": {
+          "type": "oauth2",
+          "oauth2": [
+            {
+              "key": "clientId",
+              "value": "{{web_app_client_id}}",
+              "type": "string"
+            },
+            {
+              "key": "tokenName",
+              "value": "",
+              "type": "string"
+            },
+            {
+              "key": "tokenType",
+              "value": "",
+              "type": "string"
+            },
+            {
+              "key": "accessToken",
+              "value": "",
+              "type": "string"
+            },
+            {
+              "key": "tokenRequestParams",
+              "value": [],
+              "type": "any"
+            },
+            {
+              "key": "authUrl",
+              "value": "{{auth_url}}",
+              "type": "string"
+            },
+            {
+              "key": "accessTokenUrl",
+              "value": "{{token_url}}",
+              "type": "string"
+            },
+            {
+              "key": "scope",
+              "value": "openid profile email required_scope urn:zitadel:iam:org:project:id:{{project_id}}:aud ",
+              "type": "string"
+            },
+            {
+              "key": "headerPrefix",
+              "value": "Bearer",
+              "type": "string"
+            },
+            {
+              "key": "grant_type",
+              "value": "authorization_code_with_pkce",
+              "type": "string"
+            },
+            {
+              "key": "code_verifier",
+              "value": "pepsicola123",
+              "type": "string"
+            },
+            {
+              "key": "addTokenTo",
+              "value": "header",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{your_zitadel_domain}}/oidc/v1/userinfo",
+          "host": [
+            "{{your_zitadel_domain}}"
+          ],
+          "path": [
+            "oidc",
+            "v1",
+            "userinfo"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Unprotected API Call",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "http://localhost:3000/simple-get",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "3000",
+          "path": [
+            "simple-get"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Protected API Call",
+      "event": [
+        {
+          "listen": "prerequest",
+          "script": {
+            "exec": [
+              "",
+              ""
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "auth": {
+          "type": "bearer",
+          "bearer": [
+            {
+              "key": "token",
+              "value": "{{access_token}}",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "http://localhost:3000/protected-get",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "3000",
+          "path": [
+            "protected-get"
+          ]
+        }
+      },
+      "response": []
+    }
+  ],
+  "event": [
+    {
+      "listen": "prerequest",
+      "script": {
+        "type": "text/javascript",
+        "exec": [
+          ""
+        ]
+      }
+    },
+    {
+      "listen": "test",
+      "script": {
+        "type": "text/javascript",
+        "exec": [
+          ""
+        ]
+      }
+    }
+  ],
+  "variable": [
+    {
+      "key": "client_id",
+      "value": "253xxxxxxxxxx@test"
+    },
+    {
+      "key": "project_id",
+      "value": "25xxxxxxxxx981\n",
+      "type": "string"
+    },
+    {
+      "key": "auth_url",
+      "value": "https://your_domain.zitadel.cloud/oauth/v2/authorize"
+    },
+    {
+      "key": "token_url",
+      "value": "token_url"
+    }
+  ]
+}

--- a/internal/templatecatalog/helpers_test.go
+++ b/internal/templatecatalog/helpers_test.go
@@ -1,0 +1,97 @@
+package templatecatalog
+
+import (
+	"archive/zip"
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestExtractZipCopiesFiles(t *testing.T) {
+	var archive bytes.Buffer
+	writer := zip.NewWriter(&archive)
+
+	file, err := writer.Create("templates/example.txt")
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if _, err := file.Write([]byte("hello")); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	reader, err := zip.NewReader(bytes.NewReader(archive.Bytes()), int64(archive.Len()))
+	if err != nil {
+		t.Fatalf("NewReader() error = %v", err)
+	}
+
+	dest := t.TempDir()
+	if err := extractZip(reader, dest); err != nil {
+		t.Fatalf("extractZip() error = %v", err)
+	}
+
+	payload, err := os.ReadFile(filepath.Join(dest, "templates", "example.txt"))
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if string(payload) != "hello" {
+		t.Fatalf("expected hello, got %q", payload)
+	}
+}
+
+func TestExtractZipRejectsEscapingEntry(t *testing.T) {
+	var archive bytes.Buffer
+	writer := zip.NewWriter(&archive)
+
+	file, err := writer.Create("../escape.txt")
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if _, err := file.Write([]byte("bad")); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	reader, err := zip.NewReader(bytes.NewReader(archive.Bytes()), int64(archive.Len()))
+	if err != nil {
+		t.Fatalf("NewReader() error = %v", err)
+	}
+
+	if err := extractZip(reader, t.TempDir()); err == nil {
+		t.Fatal("expected escaping zip entry to fail")
+	}
+}
+
+func TestRenderTreeRendersFileNamesAndBodies(t *testing.T) {
+	source := t.TempDir()
+	target := t.TempDir()
+
+	sourceDir := filepath.Join(source, "files")
+	if err := os.MkdirAll(filepath.Join(sourceDir, "{{ .Name }}"), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sourceDir, "{{ .Name }}", "hello-{{ .Name }}.txt"), []byte("hello {{ .Name }}"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	rendered, err := renderTree(sourceDir, target, map[string]any{"Name": "orders"})
+	if err != nil {
+		t.Fatalf("renderTree() error = %v", err)
+	}
+	if rendered != 1 {
+		t.Fatalf("expected one rendered file, got %d", rendered)
+	}
+
+	payload, err := os.ReadFile(filepath.Join(target, "orders", "hello-orders.txt"))
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if string(payload) != "hello orders" {
+		t.Fatalf("expected rendered template body, got %q", payload)
+	}
+}


### PR DESCRIPTION
## Summary

Adds the full generate/codegen pipeline for Scala/sbt Gatling output across Swagger/OpenAPI, HAR, and Postman inputs. This includes renderer templates, CLI wiring, conflict handling, and realistic parser fixtures for OpenAPI 3.0/3.1, HAR examples, and Postman collections.

## Changes

- add Scala/sbt renderer with embedded templates and golden tests
- add `galaxio generate swagger`, `galaxio generate har`, and `galaxio generate postman` commands
- add conflict resolution strategies and `--init` project overlay flow
- extend Swagger parser to support OpenAPI 3.0 and 3.1 fixtures
- add HAR parser with static-resource filtering and raw body preservation
- add Postman Collection v2.1 parser with variable mapping, auth hints, and prerequest TODO comments
- add realistic fixtures and CLI/parser integration tests

## Testing

- `go test ./...`

Closes #20
Closes #21
Closes #22
Closes #23
Closes #24
Closes #25
Closes #26