### PR TITLE
docs: improve onboarding — feature overview, generate docs, env vars, examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,21 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/galax-io/galaxio-cli)](https://goreportcard.com/report/github.com/galax-io/galaxio-cli)
 [![License](https://img.shields.io/github/license/galax-io/galaxio-cli)](https://github.com/galax-io/galaxio-cli/blob/main/LICENSE)
 
-`galaxio` is the command-line interface for Galaxio workflows.
+`galaxio` is a CLI for Gatling performance testing workflows. It scaffolds new
+load-test projects from templates and generates Gatling scripts from API
+specifications.
 
-This is the initial version of the CLI. It includes help, version output, shell
-completion, and stable exit codes for scripts and CI.
+**Key features:**
+
+- `template init` — scaffold a ready-to-compile Gatling project from a template
+- `template list` — discover available templates from any registry
+- `generate swagger / har / postman` — generate Gatling scripts from an existing API spec
+- `doctor` — validate CLI configuration and registry access
+- `update` — self-update from GitHub Releases
 
 ## Install
 
 ### Supported platforms
-
-Release binaries are built for every OS/architecture combination below.
 
 | OS | Arch | `go install` | Shell installer | Manual download |
 | --- | --- | :---: | :---: | :---: |
@@ -72,7 +77,7 @@ Archives are named `galaxio_<version>_<os>_<arch>.tar.gz` (`.zip` on Windows).
 3. Extract the `galaxio` binary (or `galaxio.exe` on Windows).
 4. Move it to a directory on your `PATH`.
 
-### Windows recommended path
+### Windows
 
 Windows does not ship with a POSIX shell, so use one of:
 
@@ -118,88 +123,49 @@ export PATH="$(go env GOPATH)/bin:$PATH"
 setx Path "%Path%;%USERPROFILE%\go\bin"
 ```
 
-### Troubleshooting
+### Troubleshooting installation
 
 #### `command not found` after install
 
-The binary is not on your `PATH`. Check where it was installed and add that
-directory (see [PATH setup](#path-setup)). Open a new terminal session after
-changing `PATH`.
+The binary is not on your `PATH`. Check where it was installed:
 
 ```sh
-# Find the binary:
 ls ~/.local/bin/galaxio        # shell installer default
 ls "$(go env GOPATH)/bin/galaxio"  # go install default
 ```
 
+Open a new terminal after changing `PATH`.
+
 #### `unsupported arch` from the shell installer
 
-The installer only recognises `x86_64`/`amd64` and `arm64`/`aarch64`. If
-`uname -m` returns something else (for example `armv7l` on a 32-bit ARM
-device), use `go install` to cross-compile for your architecture instead.
+The installer only recognises `x86_64`/`amd64` and `arm64`/`aarch64`. For
+other architectures (e.g. `armv7l`), use `go install` instead.
 
 #### GitHub API / network / proxy errors
-
-The shell installer downloads from the GitHub API and Releases CDN. Common
-failures:
 
 | Symptom | Likely cause | Fix |
 | --- | --- | --- |
 | `curl: (7) Failed to connect` | Corporate proxy or firewall | Set `https_proxy` before running the installer: `https_proxy=http://proxy:port sh scripts/install.sh` |
-| `curl: (28) Connection timed out` | Slow or blocked network | Retry, or download the binary manually from a browser |
-| HTTP 403 / rate-limit error | GitHub API rate limit (60 req/h unauthenticated) | Wait an hour, or download the binary manually from the [Releases](https://github.com/galax-io/galaxio-cli/releases) page |
-| `release asset not found` | OS/arch not in the release | Verify your platform is in the support matrix above; fall back to `go install` |
+| `curl: (28) Connection timed out` | Slow or blocked network | Retry, or download the binary manually |
+| HTTP 403 / rate-limit error | GitHub API rate limit (60 req/h unauthenticated) | Wait an hour, or download manually from the [Releases](https://github.com/galax-io/galaxio-cli/releases) page |
+| `release asset not found` | OS/arch not in the release | Verify your platform is in the support matrix; fall back to `go install` |
 
 #### Checksum verification fails
 
-If `shasum` reports a mismatch, the download may be corrupted or tampered with.
-Delete the partial install and retry:
+The download may be corrupted. Delete the partial install and retry:
 
 ```sh
 rm -f ~/.local/bin/galaxio
 curl -fsSL https://raw.githubusercontent.com/galax-io/galaxio-cli/main/scripts/install.sh | sh
 ```
 
-If the problem persists, download the archive and `checksums.txt` manually and
-compare.
-
 ## Usage
 
-Show available commands and flags:
-
 ```sh
-galaxio --help
-```
-
-Print build information:
-
-```sh
-galaxio version
-galaxio --version
-```
-
-Control diagnostic output:
-
-```sh
-galaxio --verbose version
-galaxio --quiet version
-galaxio --no-color version
-```
-
-Generate shell completion:
-
-```sh
-galaxio completion bash
-galaxio completion zsh
-galaxio completion fish
-galaxio completion powershell
-```
-
-Example zsh install:
-
-```sh
-mkdir -p ~/.zsh/completion
-galaxio completion zsh > ~/.zsh/completion/_galaxio
+galaxio --help          # show commands and flags
+galaxio version         # print build info
+galaxio --verbose ...   # verbose diagnostic output
+galaxio --no-color ...  # disable colour
 ```
 
 Update `galaxio` from GitHub Releases:
@@ -210,90 +176,186 @@ galaxio update --dry-run
 galaxio update --version 0.1.1
 ```
 
+Generate shell completions:
+
+```sh
+galaxio completion bash
+galaxio completion zsh
+galaxio completion fish
+
+# Install for zsh:
+mkdir -p ~/.zsh/completion
+galaxio completion zsh > ~/.zsh/completion/_galaxio
+```
+
 ## Template Workflow
 
-The CLI ships with a default registry (`github:galax-io/galaxio-template-registry`),
-so template discovery works out of the box with no configuration.
+The CLI ships with a default registry (`github:galax-io/galaxio-template-registry`).
+Template discovery works out of the box — no configuration needed.
 
-Browse available templates:
+### List available templates
 
 ```sh
 galaxio template list
+galaxio template list -o json
 ```
 
-Scaffold a new project from a template (files are written to `--destination`,
-which defaults to the current directory):
+### Scaffold a project
+
+Files are written to `--destination` (defaults to the current directory):
 
 ```sh
-galaxio template init gatling/scala-sbt -d ./my-project
-```
-
-Override template inputs with `--set`:
-
-```sh
-galaxio template init gatling/scala-sbt --set Name=orders -d ./my-project
-```
-
-Validate a template pack (useful for template authors):
-
-```sh
-galaxio template validate local:../my-templates
-```
-
-### End-to-end example
-
-```sh
-# 1. See what templates are available
-galaxio template list
-
-# 2. Create a project from a template
 galaxio template init gatling/scala-sbt -d ./perf-tests
+
+# Override template inputs
+galaxio template init gatling/scala-sbt \
+  --set Name=orders-api \
+  --set Package=org.example.perf \
+  --set PackagePath=org/example/perf \
+  -d ./perf-tests
+
+# Supply inputs from a YAML file
+galaxio template init gatling/scala-sbt --values ./values.yaml -d ./perf-tests
 ```
 
-### For template authors
+### Enable optional plugins
 
-Validate a template pack before publishing:
+Gatling templates support optional Kafka, JDBC, and AMQP plugin modules:
 
 ```sh
-galaxio template validate local:./my-pack
+galaxio template init gatling/scala-sbt \
+  --set KafkaPluginEnabled=true \
+  --set Name=orders-api \
+  -d ./perf-tests
+```
+
+See [templates-gatling](https://github.com/galax-io/templates-gatling) for the
+full list of available templates and inputs.
+
+### Scaffold and overlay generated files together
+
+Use `--init` on a `generate` command to scaffold a full project first, then
+overlay the generated API files on top in one step:
+
+```sh
+galaxio generate swagger --from ./petstore.yaml --init -d ./perf-tests
 ```
 
 ### Custom registries
 
-The default registry is used automatically. Run `template configure` only when
-you need a different registry:
+The default registry is used automatically. Override it only when you need a
+different source:
 
 ```sh
 galaxio template configure --registry github:my-org/my-registry
-galaxio template configure --show
+galaxio template configure --show   # inspect current setting
+
+# Override for a single command without changing config
+galaxio template init mypack/mytemplate --registry local:/path/to/registry
 ```
 
-For manifest format details and local examples, see
-[docs/templates/README.md](docs/templates/README.md) and `examples/templates/`.
+Registry source formats:
+
+| Format | Example | Notes |
+| --- | --- | --- |
+| `github:owner/repo` | `github:galax-io/templates-gatling` | Resolves pack `version` to GitHub release tag `v{version}` |
+| `local:path` | `local:../my-templates` | Resolved from current working directory |
+
+### Validate a template pack
+
+```sh
+galaxio template validate local:./my-pack
+galaxio template validate github:my-org/my-templates
+```
+
+### Clear the template cache
+
+Downloaded GitHub template archives are cached locally. Clear the cache when
+you need to force a fresh download:
+
+```sh
+galaxio template clear-cache
+```
+
+## Code Generation
+
+Generate Gatling load-test scripts from existing API specifications.
+The `--template` flag selects the Gatling DSL flavour (default: `scala-sbt`).
+
+### From Swagger / OpenAPI
+
+```sh
+galaxio generate swagger --from ./petstore.yaml
+galaxio generate swagger --from ./petstore.yaml --dest ./out
+galaxio generate swagger --from ./petstore.yaml --package org.example.perf
+galaxio generate swagger --from ./petstore.yaml -o json   # machine-readable summary
+```
+
+### From HAR recording
+
+```sh
+galaxio generate har --from ./recording.har
+galaxio generate har --from ./recording.har --dest ./out --include-static
+```
+
+### From Postman collection
+
+```sh
+galaxio generate postman --from ./collection.json
+galaxio generate postman --from ./collection.json --dest ./out
+```
+
+### Conflict strategy (`--if-exists`)
+
+When generating into a directory that already contains files, control how
+conflicts are resolved:
+
+| Strategy | Behaviour |
+| --- | --- |
+| `suffix` (default) | Writes `file.generated.scala` alongside the existing `file.scala` |
+| `merge` | Writes conflict markers (`<<<< generated / ==== / >>>> existing`) into the existing file |
+| `skip` | Leaves the existing file untouched and emits a warning to stderr |
+| `overwrite` | Replaces the existing file; skips the write if content is identical |
+
+```sh
+galaxio generate swagger --from ./petstore.yaml --if-exists overwrite
+galaxio generate swagger --from ./petstore.yaml --if-exists skip
+```
+
+## Diagnostics
+
+Check CLI configuration and registry connectivity:
+
+```sh
+galaxio doctor
+galaxio doctor --registry github:my-org/my-registry
+galaxio doctor -o json
+```
+
+`doctor` verifies that the configured registry is reachable, the pack manifest
+is valid, and all declared templates can be resolved.
+
+## Environment Variables
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `GALAXIO_CONFIG` | `~/.galaxio/config.yaml` | Override the config file path (useful in CI or Docker) |
+| `GALAXIO_CACHE_DIR` | OS user cache dir | Override the template cache directory |
 
 ## Exit Codes
-
-`galaxio` keeps exit codes stable for scripts and CI:
 
 | Code | Meaning |
 | --- | --- |
 | `0` | Command completed successfully. |
 | `1` | Runtime failure while executing a valid command. |
-| `2` | Usage error such as invalid flags, arguments, or commands. |
+| `2` | Usage error — invalid flags, arguments, or commands. |
 
 ## Build From Source
-
-Clone the repository and build the binary:
 
 ```sh
 git clone https://github.com/galax-io/galaxio-cli.git
 cd galaxio-cli
 go build -o bin/galaxio ./cmd/galaxio
-```
-
-Run the test suite:
-
-```sh
 go test ./...
 ```
 

--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ curl -fsSL https://raw.githubusercontent.com/galax-io/galaxio-cli/main/scripts/i
 galaxio --help          # show commands and flags
 galaxio version         # print build info
 galaxio --verbose ...   # verbose diagnostic output
+galaxio --quiet ...     # suppress non-error output
 galaxio --no-color ...  # disable colour
 ```
 

--- a/docs/templates/README.md
+++ b/docs/templates/README.md
@@ -122,7 +122,7 @@ template, including manifest defaults and `--values` / `--set` overrides.
 
 `local:` sources are resolved from the current working directory.
 
-## Planned CLI Flow
+## CLI Reference
 
 ```sh
 galaxio template list
@@ -133,7 +133,7 @@ galaxio template validate github:galax-io/templates-gatling
 galaxio doctor
 ```
 
-Persistent configuration is also supported:
+Persistent configuration:
 
 ```sh
 galaxio template configure --show

--- a/examples/templates/packs/basic/service/files/cmd/{{ .Name }}/main.go
+++ b/examples/templates/packs/basic/service/files/cmd/{{ .Name }}/main.go
@@ -1,0 +1,10 @@
+// Package main is the entry point for {{ .Name }}.
+// Module: {{ .Module }}
+// Owner: {{ .Owner }}
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("{{ .Name }} started")
+}

--- a/examples/templates/packs/basic/service/galaxio-template.yaml
+++ b/examples/templates/packs/basic/service/galaxio-template.yaml
@@ -20,6 +20,13 @@ inputs:
     type: string
     default: Platform Team
     description: Team or owner label shown in the README.
+  MetricsEnabled:
+    type: string
+    default: "false"
+    description: Overlay the metrics plugin files when set to true.
 files:
   - from: files
     to: .
+  - from: plugins/metrics
+    to: .
+    if: '{{ .MetricsEnabled }}'

--- a/examples/templates/packs/basic/service/plugins/metrics/metrics.go
+++ b/examples/templates/packs/basic/service/plugins/metrics/metrics.go
@@ -1,0 +1,13 @@
+// Package metrics is rendered only when MetricsEnabled=true.
+// This file is an example of a conditional plugin overlay.
+package metrics
+
+// Collector is a placeholder metrics collector for {{ .Name }}.
+type Collector struct {
+	ServiceName string
+}
+
+// New returns a Collector for the {{ .Name }} service.
+func New() *Collector {
+	return &Collector{ServiceName: "{{ .Name }}"}
+}


### PR DESCRIPTION
## Summary

- Replace stale intro paragraph with accurate feature summary (template, generate, doctor, update)
- Add Code Generation section documenting `generate swagger/har/postman` — previously absent from README entirely
- Document `--if-exists` conflict strategies with behaviour table (suffix/merge/skip/overwrite)
- Add `doctor` command to Usage section
- Add Environment Variables section (`GALAXIO_CONFIG`, `GALAXIO_CACHE_DIR`)
- Document `--init` flag and registry source formats
- Remove stale "Planned CLI Flow" heading in `docs/templates/README.md` — commands are shipped
- Expand `examples/templates/` with plugin overlay, conditional `if:` mapping, and templated file path

## Test plan

- [ ] README renders correctly on GitHub
- [ ] All example commands are accurate and copy-pasteable
- [ ] `examples/templates/` passes `galaxio template validate local:examples/templates/packs/basic`
- [ ] No broken links

🤖 Generated with [Claude Code](https://claude.com/claude-code)