### PR TITLE
feat: promote generate command to stable — remove feature flag gate

### DIFF
--- a/cmd/galaxio/generate.go
+++ b/cmd/galaxio/generate.go
@@ -3,7 +3,6 @@ package main
 import (
 	"strings"
 
-	"github.com/galax-io/galaxio-cli/internal/featureflags"
 	"github.com/spf13/cobra"
 )
 
@@ -69,32 +68,3 @@ func newGenerateCommand() *cobra.Command {
 	return cmd
 }
 
-func validateExperimentalCommand(args []string) error {
-	command := firstCommandArg(args)
-	if command == "" {
-		return nil
-	}
-
-	flag, ok := featureflags.LookupCommandFlag(command)
-	if !ok || featureflags.Enabled(flag) {
-		return nil
-	}
-
-	return UsageError{Err: featureflags.DisabledCommandError(flag)}
-}
-
-func firstCommandArg(args []string) string {
-	for _, arg := range args {
-		if arg == "--" {
-			return ""
-		}
-		if arg == "help" {
-			continue
-		}
-		if len(arg) > 0 && arg[0] == '-' {
-			continue
-		}
-		return arg
-	}
-	return ""
-}

--- a/cmd/galaxio/generate.go
+++ b/cmd/galaxio/generate.go
@@ -67,4 +67,3 @@ func newGenerateCommand() *cobra.Command {
 
 	return cmd
 }
-

--- a/cmd/galaxio/generate_har_test.go
+++ b/cmd/galaxio/generate_har_test.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-
 )
 
 func TestGenerateHARWritesFilesAndPrintsSummary(t *testing.T) {

--- a/cmd/galaxio/generate_har_test.go
+++ b/cmd/galaxio/generate_har_test.go
@@ -7,11 +7,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/galax-io/galaxio-cli/internal/featureflags"
 )
 
 func TestGenerateHARWritesFilesAndPrintsSummary(t *testing.T) {
-	t.Setenv(featureflags.Generate.EnvVar, "true")
 
 	dest := t.TempDir()
 	source := filepath.Join("..", "..", "internal", "codegen", "testdata", "har-application-json.json")
@@ -77,7 +75,6 @@ func TestGenerateHARWritesFilesAndPrintsSummary(t *testing.T) {
 }
 
 func TestGenerateHARIncludeStaticKeepsAssetRequests(t *testing.T) {
-	t.Setenv(featureflags.Generate.EnvVar, "true")
 
 	dest := t.TempDir()
 	source := filepath.Join("..", "..", "internal", "codegen", "testdata", "har-static-asset.json")
@@ -110,7 +107,6 @@ func TestGenerateHARIncludeStaticKeepsAssetRequests(t *testing.T) {
 }
 
 func TestGenerateHARSupportsJSONOutput(t *testing.T) {
-	t.Setenv(featureflags.Generate.EnvVar, "true")
 
 	dest := t.TempDir()
 	source := filepath.Join("..", "..", "internal", "codegen", "testdata", "har-application-json.json")
@@ -149,7 +145,6 @@ func TestGenerateHARSupportsJSONOutput(t *testing.T) {
 }
 
 func TestGenerateHARRejectsInvalidHAR(t *testing.T) {
-	t.Setenv(featureflags.Generate.EnvVar, "true")
 
 	source := filepath.Join(t.TempDir(), "invalid.har")
 	if err := os.WriteFile(source, []byte(`{"log":{}}`), 0o644); err != nil {

--- a/cmd/galaxio/generate_postman_test.go
+++ b/cmd/galaxio/generate_postman_test.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-
 )
 
 func TestGeneratePostmanWritesFilesAndPrintsSummary(t *testing.T) {

--- a/cmd/galaxio/generate_postman_test.go
+++ b/cmd/galaxio/generate_postman_test.go
@@ -7,11 +7,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/galax-io/galaxio-cli/internal/featureflags"
 )
 
 func TestGeneratePostmanWritesFilesAndPrintsSummary(t *testing.T) {
-	t.Setenv(featureflags.Generate.EnvVar, "true")
 
 	dest := t.TempDir()
 	source := filepath.Join("..", "..", "internal", "codegen", "testdata", "sample-collection.json")
@@ -82,7 +80,6 @@ func TestGeneratePostmanWritesFilesAndPrintsSummary(t *testing.T) {
 }
 
 func TestGeneratePostmanSupportsJSONOutput(t *testing.T) {
-	t.Setenv(featureflags.Generate.EnvVar, "true")
 
 	dest := t.TempDir()
 	source := filepath.Join("..", "..", "internal", "codegen", "testdata", "sample-collection.json")
@@ -118,7 +115,6 @@ func TestGeneratePostmanSupportsJSONOutput(t *testing.T) {
 }
 
 func TestGeneratePostmanRejectsInvalidCollection(t *testing.T) {
-	t.Setenv(featureflags.Generate.EnvVar, "true")
 
 	source := filepath.Join(t.TempDir(), "invalid-postman.json")
 	if err := os.WriteFile(source, []byte(`{"info":{}}`), 0o644); err != nil {
@@ -139,7 +135,6 @@ func TestGeneratePostmanRejectsInvalidCollection(t *testing.T) {
 }
 
 func TestGeneratePostmanSupportsZitadelFixture(t *testing.T) {
-	t.Setenv(featureflags.Generate.EnvVar, "true")
 
 	dest := t.TempDir()
 	source := filepath.Join("..", "..", "internal", "codegen", "testdata", "zitadel.postman_collection.json")

--- a/cmd/galaxio/generate_swagger_test.go
+++ b/cmd/galaxio/generate_swagger_test.go
@@ -7,11 +7,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/galax-io/galaxio-cli/internal/featureflags"
 )
 
 func TestGenerateCommandPrintsHelpWhenEnabled(t *testing.T) {
-	t.Setenv(featureflags.Generate.EnvVar, "true")
 
 	code, stdout, stderr := runCLI("generate")
 
@@ -29,7 +27,6 @@ func TestGenerateCommandPrintsHelpWhenEnabled(t *testing.T) {
 }
 
 func TestGenerateSwaggerWritesFilesAndPrintsSummary(t *testing.T) {
-	t.Setenv(featureflags.Generate.EnvVar, "true")
 
 	dest := t.TempDir()
 	source := filepath.Join("..", "..", "internal", "codegen", "testdata", "petstore-swagger2.yaml")
@@ -84,7 +81,6 @@ func TestGenerateSwaggerWritesFilesAndPrintsSummary(t *testing.T) {
 }
 
 func TestGenerateSwaggerSupportsJSONOutput(t *testing.T) {
-	t.Setenv(featureflags.Generate.EnvVar, "true")
 
 	dest := t.TempDir()
 	source := filepath.Join("..", "..", "internal", "codegen", "testdata", "petstore-swagger2.yaml")
@@ -126,7 +122,6 @@ func TestGenerateSwaggerSupportsJSONOutput(t *testing.T) {
 }
 
 func TestGenerateSwaggerSupportsOpenAPI3Input(t *testing.T) {
-	t.Setenv(featureflags.Generate.EnvVar, "true")
 
 	dest := t.TempDir()
 	source := filepath.Join("..", "..", "internal", "codegen", "testdata", "petstore-openapi3.yaml")
@@ -174,7 +169,6 @@ func TestGenerateSwaggerSupportsOpenAPI3Input(t *testing.T) {
 }
 
 func TestGenerateSwaggerRejectsMissingSourceFile(t *testing.T) {
-	t.Setenv(featureflags.Generate.EnvVar, "true")
 
 	code, stdout, stderr := runCLI("generate", "swagger", "--from", filepath.Join(t.TempDir(), "missing.yaml"))
 
@@ -192,7 +186,6 @@ func TestGenerateSwaggerRejectsMissingSourceFile(t *testing.T) {
 }
 
 func TestGenerateSwaggerRejectsInvalidSwagger(t *testing.T) {
-	t.Setenv(featureflags.Generate.EnvVar, "true")
 
 	source := filepath.Join(t.TempDir(), "invalid.yaml")
 	if err := os.WriteFile(source, []byte("swagger: ["), 0o644); err != nil {
@@ -213,7 +206,6 @@ func TestGenerateSwaggerRejectsInvalidSwagger(t *testing.T) {
 }
 
 func TestGenerateSwaggerRejectsUnknownTemplate(t *testing.T) {
-	t.Setenv(featureflags.Generate.EnvVar, "true")
 
 	source := filepath.Join("..", "..", "internal", "codegen", "testdata", "petstore-swagger2.yaml")
 	code, stdout, stderr := runCLI("generate", "swagger", "--from", source, "--template", "java-gradle")
@@ -230,7 +222,6 @@ func TestGenerateSwaggerRejectsUnknownTemplate(t *testing.T) {
 }
 
 func TestGenerateSwaggerRequiresFromFlag(t *testing.T) {
-	t.Setenv(featureflags.Generate.EnvVar, "true")
 
 	code, stdout, stderr := runCLI("generate", "swagger")
 
@@ -246,7 +237,6 @@ func TestGenerateSwaggerRequiresFromFlag(t *testing.T) {
 }
 
 func TestGenerateSwaggerSuffixWritesGeneratedSiblingOnSecondRun(t *testing.T) {
-	t.Setenv(featureflags.Generate.EnvVar, "true")
 
 	dest := t.TempDir()
 	source := filepath.Join("..", "..", "internal", "codegen", "testdata", "petstore-swagger2.yaml")
@@ -272,7 +262,6 @@ func TestGenerateSwaggerSuffixWritesGeneratedSiblingOnSecondRun(t *testing.T) {
 }
 
 func TestGenerateSwaggerMergeWritesConflictMarkers(t *testing.T) {
-	t.Setenv(featureflags.Generate.EnvVar, "true")
 
 	dest := t.TempDir()
 	source := filepath.Join("..", "..", "internal", "codegen", "testdata", "petstore-swagger2.yaml")
@@ -310,7 +299,6 @@ func TestGenerateSwaggerMergeWritesConflictMarkers(t *testing.T) {
 }
 
 func TestGenerateSwaggerSkipLeavesOriginalUntouched(t *testing.T) {
-	t.Setenv(featureflags.Generate.EnvVar, "true")
 
 	dest := t.TempDir()
 	source := filepath.Join("..", "..", "internal", "codegen", "testdata", "petstore-swagger2.yaml")
@@ -349,7 +337,6 @@ func TestGenerateSwaggerSkipLeavesOriginalUntouched(t *testing.T) {
 }
 
 func TestGenerateSwaggerOverwriteReplacesExistingFile(t *testing.T) {
-	t.Setenv(featureflags.Generate.EnvVar, "true")
 
 	dest := t.TempDir()
 	source := filepath.Join("..", "..", "internal", "codegen", "testdata", "petstore-swagger2.yaml")
@@ -385,7 +372,6 @@ func TestGenerateSwaggerOverwriteReplacesExistingFile(t *testing.T) {
 }
 
 func TestGenerateSwaggerRejectsUnknownIfExistsStrategy(t *testing.T) {
-	t.Setenv(featureflags.Generate.EnvVar, "true")
 
 	source := filepath.Join("..", "..", "internal", "codegen", "testdata", "petstore-swagger2.yaml")
 	code, stdout, stderr := runCLI("generate", "swagger", "--from", source, "--if-exists", "explode")
@@ -402,7 +388,6 @@ func TestGenerateSwaggerRejectsUnknownIfExistsStrategy(t *testing.T) {
 }
 
 func TestGenerateSwaggerInitRendersProjectAndOverlay(t *testing.T) {
-	t.Setenv(featureflags.Generate.EnvVar, "true")
 
 	registryRoot := writeGenerateInitTemplateCatalogFixture(t)
 	dest := t.TempDir()
@@ -456,7 +441,6 @@ func TestGenerateSwaggerInitRendersProjectAndOverlay(t *testing.T) {
 }
 
 func TestGenerateSwaggerInitRejectsExistingDestinationWithoutExplicitIfExists(t *testing.T) {
-	t.Setenv(featureflags.Generate.EnvVar, "true")
 
 	registryRoot := writeGenerateInitTemplateCatalogFixture(t)
 	dest := t.TempDir()
@@ -484,7 +468,6 @@ func TestGenerateSwaggerInitRejectsExistingDestinationWithoutExplicitIfExists(t 
 }
 
 func TestGenerateSwaggerInitAllowsExistingDestinationWithExplicitIfExists(t *testing.T) {
-	t.Setenv(featureflags.Generate.EnvVar, "true")
 
 	registryRoot := writeGenerateInitTemplateCatalogFixture(t)
 	dest := t.TempDir()

--- a/cmd/galaxio/generate_swagger_test.go
+++ b/cmd/galaxio/generate_swagger_test.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-
 )
 
 func TestGenerateCommandPrintsHelpWhenEnabled(t *testing.T) {

--- a/cmd/galaxio/root.go
+++ b/cmd/galaxio/root.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/galax-io/galaxio-cli/internal/featureflags"
 	"github.com/spf13/cobra"
 )
 
@@ -77,12 +76,10 @@ func newRootCommand() *cobra.Command {
 	cmd.PersistentFlags().BoolVarP(&opts.quiet, "quiet", "q", false, "suppress non-essential output")
 
 	cmd.AddCommand(newDoctorCommand())
+	cmd.AddCommand(newGenerateCommand())
 	cmd.AddCommand(newTemplateCommand())
 	cmd.AddCommand(newUpdateCommand())
 	cmd.AddCommand(newVersionCommand())
-	if featureflags.Enabled(featureflags.Generate) {
-		cmd.AddCommand(newGenerateCommand())
-	}
 
 	return cmd
 }
@@ -93,10 +90,7 @@ func execute(args []string, stdout io.Writer, stderr io.Writer) int {
 	cmd.SetOut(stdout)
 	cmd.SetErr(stderr)
 
-	err := validateExperimentalCommand(args)
-	if err == nil {
-		err = cmd.Execute()
-	}
+	err := cmd.Execute()
 	err = normalizeCLIError(err)
 	if err != nil {
 		_, _ = fmt.Fprintf(stderr, "Error: %s\n", err)

--- a/cmd/galaxio/root_test.go
+++ b/cmd/galaxio/root_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/galax-io/galaxio-cli/internal/buildinfo"
-	"github.com/galax-io/galaxio-cli/internal/featureflags"
 	"github.com/galax-io/galaxio-cli/internal/selfupdate"
 	"github.com/galax-io/galaxio-cli/internal/templatecatalog"
 	"github.com/spf13/cobra"
@@ -24,8 +23,6 @@ func runCLI(args ...string) (int, string, string) {
 }
 
 func TestHelpPrintsMinimalUsage(t *testing.T) {
-	t.Setenv(featureflags.Generate.EnvVar, "false")
-
 	code, stdout, stderr := runCLI("--help")
 
 	if code != exitOK {
@@ -34,51 +31,14 @@ func TestHelpPrintsMinimalUsage(t *testing.T) {
 	if stderr != "" {
 		t.Fatalf("expected empty stderr, got %q", stderr)
 	}
-	for _, want := range []string{"Enterprise command-line toolkit", "Usage:", "galaxio [flags]", "completion", "doctor", "template", "update", "version"} {
+	for _, want := range []string{"Enterprise command-line toolkit", "Usage:", "galaxio [flags]", "completion", "doctor", "generate", "template", "update", "version"} {
 		if !strings.Contains(stdout, want) {
 			t.Fatalf("expected help output to contain %q, got %q", want, stdout)
 		}
 	}
-	if strings.Contains(stdout, "generate") {
-		t.Fatalf("did not expect generate in help when feature is disabled, got %q", stdout)
-	}
 }
 
-func TestHelpShowsGenerateWhenFeatureEnabled(t *testing.T) {
-	t.Setenv(featureflags.Generate.EnvVar, "true")
-
-	code, stdout, stderr := runCLI("--help")
-
-	if code != exitOK {
-		t.Fatalf("expected exit code %d, got %d", exitOK, code)
-	}
-	if stderr != "" {
-		t.Fatalf("expected empty stderr, got %q", stderr)
-	}
-	if !strings.Contains(stdout, "generate") {
-		t.Fatalf("expected generate in help when feature is enabled, got %q", stdout)
-	}
-}
-
-func TestGenerateCommandReturnsFeatureFlagErrorWhenDisabled(t *testing.T) {
-	t.Setenv(featureflags.Generate.EnvVar, "false")
-
-	code, stdout, stderr := runCLI("generate")
-
-	if code != exitUsage {
-		t.Fatalf("expected exit code %d, got %d", exitUsage, code)
-	}
-	if stdout != "" {
-		t.Fatalf("expected empty stdout, got %q", stdout)
-	}
-	if want := "GALAXIO_FEATURE_GENERATE=true"; !strings.Contains(stderr, want) {
-		t.Fatalf("expected feature flag guidance %q, got %q", want, stderr)
-	}
-}
-
-func TestGenerateCommandIsRegisteredWhenEnabled(t *testing.T) {
-	t.Setenv(featureflags.Generate.EnvVar, "true")
-
+func TestGenerateCommandPrintsHelp(t *testing.T) {
 	code, stdout, stderr := runCLI("generate")
 
 	if code != exitOK {
@@ -92,9 +52,7 @@ func TestGenerateCommandIsRegisteredWhenEnabled(t *testing.T) {
 	}
 }
 
-func TestGenerateSubcommandsAreShownWhenEnabled(t *testing.T) {
-	t.Setenv(featureflags.Generate.EnvVar, "true")
-
+func TestGenerateSubcommandsAreShown(t *testing.T) {
 	code, stdout, stderr := runCLI("generate", "--help")
 
 	if code != exitOK {

--- a/internal/featureflags/flags.go
+++ b/internal/featureflags/flags.go
@@ -12,17 +12,7 @@ type Flag struct {
 	EnvVar  string
 }
 
-var (
-	// Generate gates the experimental generate command.
-	Generate = Flag{
-		Command: "generate",
-		EnvVar:  "GALAXIO_FEATURE_GENERATE",
-	}
-
-	commandFlags = map[string]Flag{
-		Generate.Command: Generate,
-	}
-)
+var commandFlags = map[string]Flag{}
 
 // Enabled reports whether a feature flag is enabled through its environment variable.
 func Enabled(flag Flag) bool {

--- a/internal/featureflags/flags_test.go
+++ b/internal/featureflags/flags_test.go
@@ -22,12 +22,8 @@ func TestEnabled(t *testing.T) {
 }
 
 func TestLookupCommandFlag(t *testing.T) {
-	flag, ok := LookupCommandFlag("generate")
-	if !ok {
-		t.Fatalf("expected generate command flag to be registered")
-	}
-	if flag != Generate {
-		t.Fatalf("expected generate flag, got %#v", flag)
+	if _, ok := LookupCommandFlag("generate"); ok {
+		t.Fatalf("generate should no longer be a gated command")
 	}
 
 	if _, ok := LookupCommandFlag("missing"); ok {
@@ -36,8 +32,9 @@ func TestLookupCommandFlag(t *testing.T) {
 }
 
 func TestDisabledCommandError(t *testing.T) {
-	err := DisabledCommandError(Generate)
-	if got, want := err.Error(), "\"generate\" is an experimental command and is currently disabled; enable it with GALAXIO_FEATURE_GENERATE=true"; got != want {
+	flag := Flag{Command: "example", EnvVar: "GALAXIO_FEATURE_EXAMPLE"}
+	err := DisabledCommandError(flag)
+	if got, want := err.Error(), "\"example\" is an experimental command and is currently disabled; enable it with GALAXIO_FEATURE_EXAMPLE=true"; got != want {
 		t.Fatalf("expected %q, got %q", want, got)
 	}
 }


### PR DESCRIPTION
## Summary

- `generate` command (`swagger` / `har` / `postman`) is now always registered and visible in `--help` without any environment variable
- Remove `GALAXIO_FEATURE_GENERATE` gate from root command registration
- Remove `validateExperimentalCommand()` and `firstCommandArg()` helpers from `generate.go`
- Remove `Generate` flag from `featureflags` package; keep package infrastructure for future experimental features
- Update tests: remove `t.Setenv(featureflags.Generate.EnvVar, "true")` from all generate test files, replace FF-specific root tests with unconditional coverage

## Test plan

- [ ] `galaxio --help` shows `generate` without any env var
- [ ] `galaxio generate --help` shows swagger/har/postman subcommands
- [ ] All 89 existing tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)