### PR TITLE
[codex] docker hub publish

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+.github
+.idea
+.vscode
+bin
+dist
+coverage.out
+galaxio
+*.test

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,12 +1,12 @@
 name: docker-publish
 
 on:
+  pull_request:
   push:
     branches:
       - main
     tags:
       - "v*"
-  workflow_dispatch:
 
 permissions:
   contents: read
@@ -15,8 +15,54 @@ env:
   IMAGE_NAME: galax-io/galaxio-cli
 
 jobs:
+  build-and-validate:
+    name: build and validate image
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Prepare build metadata
+        id: buildmeta
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          version="dev"
+
+          commit="$(git rev-parse --short=12 HEAD)"
+          date="$(git log -1 --format=%cI HEAD)"
+          image_tag="${IMAGE_NAME}:pr-${{ github.event.pull_request.number }}-${GITHUB_SHA::12}"
+
+          {
+            echo "build_args<<EOF"
+            printf 'VERSION=%s\nCOMMIT=%s\nDATE=%s\n' "${version}" "${commit}" "${date}"
+            echo "EOF"
+            echo "image_tag=${image_tag}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Build image locally
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          load: true
+          push: false
+          tags: ${{ steps.buildmeta.outputs.image_tag }}
+          build-args: ${{ steps.buildmeta.outputs.build_args }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: false
+
+      - name: Validate image with utility command
+        run: docker run --rm ${{ steps.buildmeta.outputs.image_tag }} version
+
   publish:
     name: publish image
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,77 @@
+name: docker-publish
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  IMAGE_NAME: galax-io/galaxio-cli
+
+jobs:
+  publish:
+    name: publish image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern={{version}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=semver,pattern={{major}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+
+      - name: Prepare build metadata
+        id: buildmeta
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            version="${GITHUB_REF_NAME}"
+          else
+            version="dev"
+          fi
+
+          commit="$(git rev-parse --short=12 HEAD)"
+          date="$(git log -1 --format=%cI HEAD)"
+
+          {
+            echo "build_args<<EOF"
+            printf 'VERSION=%s\nCOMMIT=%s\nDATE=%s\n' "${version}" "${commit}" "${date}"
+            echo "EOF"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: ${{ steps.buildmeta.outputs.build_args }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: false

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -12,7 +12,7 @@ permissions:
   contents: read
 
 env:
-  IMAGE_NAME: ${{ secrets.DOCKER_USERNAME }}/galaxio
+  IMAGE_NAME: galax-io/galaxio
 
 jobs:
   build-and-validate:
@@ -53,8 +53,6 @@ jobs:
           push: false
           tags: ${{ steps.buildmeta.outputs.image_tag }}
           build-args: ${{ steps.buildmeta.outputs.build_args }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
           provenance: false
 
       - name: Validate image with utility command
@@ -118,6 +116,4 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: ${{ steps.buildmeta.outputs.build_args }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
           provenance: false

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -12,7 +12,7 @@ permissions:
   contents: read
 
 env:
-  IMAGE_NAME: galax-io/galaxio-cli
+  IMAGE_NAME: ${{ secrets.DOCKER_USERNAME }}/galaxio
 
 jobs:
   build-and-validate:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,43 @@
+# syntax=docker/dockerfile:1.7
+
+ARG GO_VERSION=1.25.0
+ARG DISTROLESS_BASE_IMAGE=gcr.io/distroless/static-debian12:nonroot
+
+FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-bookworm AS build
+
+WORKDIR /src
+
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/go/pkg/mod go mod download
+
+COPY . .
+
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+ARG VERSION=dev
+ARG COMMIT=none
+ARG DATE=unknown
+
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    mkdir -p /out && \
+    CGO_ENABLED=0 \
+    GOOS=${TARGETOS} \
+    GOARCH=${TARGETARCH} \
+    GOARM=${TARGETVARIANT#v} \
+    go build -trimpath -ldflags="-s -w \
+      -X github.com/galax-io/galaxio-cli/internal/buildinfo.Version=${VERSION} \
+      -X github.com/galax-io/galaxio-cli/internal/buildinfo.Commit=${COMMIT} \
+      -X github.com/galax-io/galaxio-cli/internal/buildinfo.Date=${DATE}" \
+    -o /out/galaxio ./cmd/galaxio
+
+FROM ${DISTROLESS_BASE_IMAGE}
+
+LABEL org.opencontainers.image.title="galaxio-cli"
+LABEL org.opencontainers.image.description="CLI for Gatling performance testing workflows."
+LABEL org.opencontainers.image.source="https://github.com/galax-io/galaxio-cli"
+LABEL org.opencontainers.image.licenses="GPL-2.0-only"
+
+COPY --from=build /out/galaxio /usr/local/bin/galaxio
+
+ENTRYPOINT ["/usr/local/bin/galaxio"]

--- a/README.md
+++ b/README.md
@@ -79,18 +79,18 @@ Archives are named `galaxio_<version>_<os>_<arch>.tar.gz` (`.zip` on Windows).
 
 ### Option 4 — Docker image
 
-The image is published to Docker Hub as `galax-io/galaxio-cli`.
+The image is published to Docker Hub as `<docker-username>/galaxio`.
 
 ```sh
-docker pull galax-io/galaxio-cli:latest
-docker run --rm galax-io/galaxio-cli --help
+docker pull <docker-username>/galaxio:latest
+docker run --rm <docker-username>/galaxio --help
 ```
 
 For commands that create files, mount a working directory and set it as the
 container workdir:
 
 ```sh
-docker run --rm -v "$PWD":/work -w /work galax-io/galaxio-cli template list
+docker run --rm -v "$PWD":/work -w /work <docker-username>/galaxio template list
 ```
 
 ### Windows

--- a/README.md
+++ b/README.md
@@ -77,6 +77,22 @@ Archives are named `galaxio_<version>_<os>_<arch>.tar.gz` (`.zip` on Windows).
 3. Extract the `galaxio` binary (or `galaxio.exe` on Windows).
 4. Move it to a directory on your `PATH`.
 
+### Option 4 — Docker image
+
+The image is published to Docker Hub as `galax-io/galaxio-cli`.
+
+```sh
+docker pull galax-io/galaxio-cli:latest
+docker run --rm galax-io/galaxio-cli --help
+```
+
+For commands that create files, mount a working directory and set it as the
+container workdir:
+
+```sh
+docker run --rm -v "$PWD":/work -w /work galax-io/galaxio-cli template list
+```
+
 ### Windows
 
 Windows does not ship with a POSIX shell, so use one of:

--- a/README.md
+++ b/README.md
@@ -79,18 +79,18 @@ Archives are named `galaxio_<version>_<os>_<arch>.tar.gz` (`.zip` on Windows).
 
 ### Option 4 — Docker image
 
-The image is published to Docker Hub as `<docker-username>/galaxio`.
+The image is published to Docker Hub as `galax-io/galaxio`.
 
 ```sh
-docker pull <docker-username>/galaxio:latest
-docker run --rm <docker-username>/galaxio --help
+docker pull galax-io/galaxio:latest
+docker run --rm galax-io/galaxio --help
 ```
 
 For commands that create files, mount a working directory and set it as the
 container workdir:
 
 ```sh
-docker run --rm -v "$PWD":/work -w /work <docker-username>/galaxio template list
+docker run --rm -v "$PWD":/work -w /work galax-io/galaxio template list
 ```
 
 ### Windows


### PR DESCRIPTION
## What changed
- Added a multistage `Dockerfile` that builds `galaxio` in a Go builder stage and runs it from a `distroless` nonroot image.
- Added `.dockerignore` to keep the build context small.
- Added a `docker-publish` workflow with two modes:
  - `pull_request` builds the image locally and validates it with `docker run ... galaxio version`
  - `push` to `main` and `v*` tags publishes `<docker-username>/galaxio` to Docker Hub
- Documented Docker usage in the README.

## Why
- We wanted a reproducible container image for the CLI, with a minimal runtime and a clean publish path.
- The layout follows the distroless Go example and the existing style from `galax-io/docker-images`.

## Impact
- Pull requests now verify the image by running the CLI inside the built container.
- `main` publishes `latest` to Docker Hub.
- Release tags publish semver tags for the image.
- The runtime image stays small and non-root.

## Checks
- `go test ./...`
- `docker build -f Dockerfile -t galaxio-cli:test .` was not runnable here because the Docker daemon is unavailable in this session.
- The PR workflow is configured to run `docker run ... version` as its validation step.
