### PR TITLE
docs: add Docker Hub and size badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 [![CI](https://github.com/galax-io/galaxio-cli/actions/workflows/ci.yml/badge.svg)](https://github.com/galax-io/galaxio-cli/actions/workflows/ci.yml)
 [![Coverage](https://codecov.io/gh/galax-io/galaxio-cli/branch/main/graph/badge.svg)](https://codecov.io/gh/galax-io/galaxio-cli)
 [![Latest Release](https://img.shields.io/github/v/release/galax-io/galaxio-cli?sort=semver)](https://github.com/galax-io/galaxio-cli/releases)
+[![Docker Hub](https://shieldcn.dev/docker/v/galaxioteam/galaxio.png)](https://hub.docker.com/r/galaxioteam/galaxio)
+[![Utility Size](https://shieldcn.dev/badge/dynamic/json.png?url=https%3A%2F%2Fapi.github.com%2Frepos%2Fgalax-io%2Fgalaxio-cli%2Freleases%2Flatest&query=%24.assets%5B%3F%28%40.name.match%28%2Flinux_amd64%5C.tar%5C.gz%24%2F%29%29%5D.size&label=utility%20size&suffix=%20bytes)](https://github.com/galax-io/galaxio-cli/releases/latest)
+[![Image Size](https://shieldcn.dev/docker/size/galaxioteam/galaxio.png)](https://hub.docker.com/r/galaxioteam/galaxio)
 [![Go Report Card](https://goreportcard.com/badge/github.com/galax-io/galaxio-cli)](https://goreportcard.com/report/github.com/galax-io/galaxio-cli)
 [![License](https://img.shields.io/github/license/galax-io/galaxio-cli)](https://github.com/galax-io/galaxio-cli/blob/main/LICENSE)
 
@@ -81,6 +84,8 @@ Archives are named `galaxio_<version>_<os>_<arch>.tar.gz` (`.zip` on Windows).
 
 The image is published to Docker Hub as `galaxioteam/galaxio:<release-version>`,
 plus the alias `galaxioteam/galaxio:<major.minor>` and `galaxioteam/galaxio:latest`.
+The badges at the top show the current Docker Hub tag, the latest release
+utility size, and the compressed Docker image size.
 
 ```sh
 docker pull galaxioteam/galaxio:0.1.1


### PR DESCRIPTION
## What
- Add a Docker Hub badge for `galaxioteam/galaxio`
- Add a badge for the latest release utility size
- Add a badge for the Docker image size

## Notes
- Docker Hub namespace is `galaxioteam/galaxio`
- Utility size badge points at the latest `linux_amd64` release asset