### PR TITLE
docs: polish README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 [![CI](https://github.com/galax-io/galaxio-cli/actions/workflows/ci.yml/badge.svg)](https://github.com/galax-io/galaxio-cli/actions/workflows/ci.yml)
 [![Coverage](https://codecov.io/gh/galax-io/galaxio-cli/branch/main/graph/badge.svg)](https://codecov.io/gh/galax-io/galaxio-cli)
 [![Latest Release](https://img.shields.io/github/v/release/galax-io/galaxio-cli?sort=semver)](https://github.com/galax-io/galaxio-cli/releases)
-[![Docker Hub](https://shieldcn.dev/docker/v/galaxioteam/galaxio.png)](https://hub.docker.com/r/galaxioteam/galaxio)
-[![Utility Size](https://shieldcn.dev/badge/dynamic/json.png?url=https%3A%2F%2Fapi.github.com%2Frepos%2Fgalax-io%2Fgalaxio-cli%2Freleases%2Flatest&query=%24.assets%5B%3F%28%40.name.match%28%2Flinux_amd64%5C.tar%5C.gz%24%2F%29%29%5D.size&label=utility%20size&suffix=%20bytes)](https://github.com/galax-io/galaxio-cli/releases/latest)
-[![Image Size](https://shieldcn.dev/docker/size/galaxioteam/galaxio.png)](https://hub.docker.com/r/galaxioteam/galaxio)
+[![Docker Hub](https://shieldcn.dev/docker/v/galaxioteam/galaxio.svg)](https://hub.docker.com/r/galaxioteam/galaxio)
+[![Utility Size](https://shieldcn.dev/badge/utility%20size-5.8%20MB.svg)](https://github.com/galax-io/galaxio-cli/releases/latest)
+[![Image Size](https://shieldcn.dev/docker/size/galaxioteam/galaxio.svg)](https://hub.docker.com/r/galaxioteam/galaxio)
 [![Go Report Card](https://goreportcard.com/badge/github.com/galax-io/galaxio-cli)](https://goreportcard.com/report/github.com/galax-io/galaxio-cli)
 [![License](https://img.shields.io/github/license/galax-io/galaxio-cli)](https://github.com/galax-io/galaxio-cli/blob/main/LICENSE)
 


### PR DESCRIPTION
## What
- Use SVG badges for a crisper README header
- Show the utility size in human-readable MB instead of bytes
- Keep Docker Hub and image size badges visually consistent

## Notes
- Docker Hub namespace is `galaxioteam/galaxio`
- Utility size uses the current latest release asset size in MB